### PR TITLE
Add Dockerfiles for 3.1 and 3.2 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: bash
 services: docker
 
 env:
+  - VERSION=3.2
+  - VERSION=3.1
   - VERSION=3.0
   - VERSION=2.6
 

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -1,0 +1,68 @@
+FROM ruby:2.2-slim
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r redmine && useradd -r -g redmine redmine
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN set -x \
+	&& curl -fSL "https://github.com/krallin/tini/releases/download/v0.5.0/tini" -o /usr/local/bin/tini \
+	&& chmod +x /usr/local/bin/tini \
+	&& tini -h
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		imagemagick \
+		libmysqlclient18 \
+		libpq5 \
+		libsqlite3-0 \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV RAILS_ENV production
+WORKDIR /usr/src/redmine
+
+ENV REDMINE_VERSION 3.1.3
+ENV REDMINE_DOWNLOAD_MD5 09b0bbcef859fef51022750a94db7579
+
+RUN curl -fSL "http://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
+	&& echo "$REDMINE_DOWNLOAD_MD5 redmine.tar.gz" | md5sum -c - \
+	&& tar -xvf redmine.tar.gz --strip-components=1 \
+	&& rm redmine.tar.gz files/delete.me log/delete.me \
+	&& mkdir -p tmp/pdf public/plugin_assets \
+	&& chown -R redmine:redmine ./
+
+RUN buildDeps='\
+		gcc \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libmysqlclient-dev \
+		libpq-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+	' \
+	&& set -ex \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& bundle install --without development test \
+	&& for adapter in mysql2 postgresql sqlite3; do \
+		echo "$RAILS_ENV:" > ./config/database.yml; \
+		echo "  adapter: $adapter" >> ./config/database.yml; \
+		bundle install --without development test; \
+	done \
+	&& rm ./config/database.yml \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+
+VOLUME /usr/src/redmine/files
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+	rails|rake|passenger)
+		if [ ! -f './config/database.yml' ]; then
+			if [ "$MYSQL_PORT_3306_TCP" ]; then
+				adapter='mysql2'
+				host='mysql'
+				port="${MYSQL_PORT_3306_TCP_PORT:-3306}"
+				username="${MYSQL_ENV_MYSQL_USER:-root}"
+				password="${MYSQL_ENV_MYSQL_PASSWORD:-$MYSQL_ENV_MYSQL_ROOT_PASSWORD}"
+				database="${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+				encoding=
+			elif [ "$POSTGRES_PORT_5432_TCP" ]; then
+				adapter='postgresql'
+				host='postgres'
+				port="${POSTGRES_PORT_5432_TCP_PORT:-5432}"
+				username="${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+				password="${POSTGRES_ENV_POSTGRES_PASSWORD}"
+				database="${POSTGRES_ENV_POSTGRES_DB:-$username}"
+				encoding=utf8
+			else
+				echo >&2 'warning: missing MYSQL_PORT_3306_TCP or POSTGRES_PORT_5432_TCP environment variables'
+				echo >&2 '  Did you forget to --link some_mysql_container:mysql or some-postgres:postgres?'
+				echo >&2
+				echo >&2 '*** Using sqlite3 as fallback. ***'
+				
+				adapter='sqlite3'
+				host='localhost'
+				username='redmine'
+				database='sqlite/redmine.db'
+				encoding=utf8
+				
+				mkdir -p "$(dirname "$database")"
+				chown -R redmine:redmine "$(dirname "$database")"
+			fi
+			
+			cat > './config/database.yml' <<-YML
+				$RAILS_ENV:
+				  adapter: $adapter
+				  database: $database
+				  host: $host
+				  username: $username
+				  password: "$password"
+				  encoding: $encoding
+				  port: $port
+			YML
+		fi
+		
+		# ensure the right database adapter is active in the Gemfile.lock
+		bundle install --without development test
+		
+		if [ ! -s config/secrets.yml ]; then
+			if [ "$REDMINE_SECRET_KEY_BASE" ]; then
+				cat > 'config/secrets.yml' <<-YML
+					$RAILS_ENV:
+					  secret_key_base: "$REDMINE_SECRET_KEY_BASE"
+				YML
+			elif [ ! -f /usr/src/redmine/config/initializers/secret_token.rb ]; then
+				rake generate_secret_token
+			fi
+		fi
+		if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+			gosu redmine rake db:migrate
+		fi
+		
+		chown -R redmine:redmine files log public/plugin_assets
+		
+		# remove PID file to enable restarting the container
+		rm -f /usr/src/redmine/tmp/pids/server.pid
+		
+		if [ "$1" = 'passenger' ]; then
+			# Don't fear the reaper.
+			set -- tini -- "$@"
+		fi
+		
+		set -- gosu redmine "$@"
+		;;
+esac
+
+exec "$@"

--- a/3.1/passenger/Dockerfile
+++ b/3.1/passenger/Dockerfile
@@ -1,0 +1,15 @@
+FROM redmine:3.1
+
+ENV PASSENGER_VERSION 5.0.23
+RUN buildDeps=' \
+		make \
+	' \
+	&& set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& gem install passenger --version "$PASSENGER_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps
+RUN set -x \
+	&& passenger-config install-agent \
+	&& passenger-config install-standalone-runtime
+
+CMD ["passenger", "start"]

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,0 +1,68 @@
+FROM ruby:2.2-slim
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r redmine && useradd -r -g redmine redmine
+
+# grab gosu for easy step-down from root
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN set -x \
+	&& curl -fSL "https://github.com/krallin/tini/releases/download/v0.5.0/tini" -o /usr/local/bin/tini \
+	&& chmod +x /usr/local/bin/tini \
+	&& tini -h
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		imagemagick \
+		libmysqlclient18 \
+		libpq5 \
+		libsqlite3-0 \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV RAILS_ENV production
+WORKDIR /usr/src/redmine
+
+ENV REDMINE_VERSION 3.2.0
+ENV REDMINE_DOWNLOAD_MD5 b1050c3a0e6effd5a704ef5003d9df06
+
+RUN curl -fSL "http://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
+	&& echo "$REDMINE_DOWNLOAD_MD5 redmine.tar.gz" | md5sum -c - \
+	&& tar -xvf redmine.tar.gz --strip-components=1 \
+	&& rm redmine.tar.gz files/delete.me log/delete.me \
+	&& mkdir -p tmp/pdf public/plugin_assets \
+	&& chown -R redmine:redmine ./
+
+RUN buildDeps='\
+		gcc \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libmysqlclient-dev \
+		libpq-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+	' \
+	&& set -ex \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& bundle install --without development test \
+	&& for adapter in mysql2 postgresql sqlite3; do \
+		echo "$RAILS_ENV:" > ./config/database.yml; \
+		echo "  adapter: $adapter" >> ./config/database.yml; \
+		bundle install --without development test; \
+	done \
+	&& rm ./config/database.yml \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+
+VOLUME /usr/src/redmine/files
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+	rails|rake|passenger)
+		if [ ! -f './config/database.yml' ]; then
+			if [ "$MYSQL_PORT_3306_TCP" ]; then
+				adapter='mysql2'
+				host='mysql'
+				port="${MYSQL_PORT_3306_TCP_PORT:-3306}"
+				username="${MYSQL_ENV_MYSQL_USER:-root}"
+				password="${MYSQL_ENV_MYSQL_PASSWORD:-$MYSQL_ENV_MYSQL_ROOT_PASSWORD}"
+				database="${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+				encoding=
+			elif [ "$POSTGRES_PORT_5432_TCP" ]; then
+				adapter='postgresql'
+				host='postgres'
+				port="${POSTGRES_PORT_5432_TCP_PORT:-5432}"
+				username="${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+				password="${POSTGRES_ENV_POSTGRES_PASSWORD}"
+				database="${POSTGRES_ENV_POSTGRES_DB:-$username}"
+				encoding=utf8
+			else
+				echo >&2 'warning: missing MYSQL_PORT_3306_TCP or POSTGRES_PORT_5432_TCP environment variables'
+				echo >&2 '  Did you forget to --link some_mysql_container:mysql or some-postgres:postgres?'
+				echo >&2
+				echo >&2 '*** Using sqlite3 as fallback. ***'
+				
+				adapter='sqlite3'
+				host='localhost'
+				username='redmine'
+				database='sqlite/redmine.db'
+				encoding=utf8
+				
+				mkdir -p "$(dirname "$database")"
+				chown -R redmine:redmine "$(dirname "$database")"
+			fi
+			
+			cat > './config/database.yml' <<-YML
+				$RAILS_ENV:
+				  adapter: $adapter
+				  database: $database
+				  host: $host
+				  username: $username
+				  password: "$password"
+				  encoding: $encoding
+				  port: $port
+			YML
+		fi
+		
+		# ensure the right database adapter is active in the Gemfile.lock
+		bundle install --without development test
+		
+		if [ ! -s config/secrets.yml ]; then
+			if [ "$REDMINE_SECRET_KEY_BASE" ]; then
+				cat > 'config/secrets.yml' <<-YML
+					$RAILS_ENV:
+					  secret_key_base: "$REDMINE_SECRET_KEY_BASE"
+				YML
+			elif [ ! -f /usr/src/redmine/config/initializers/secret_token.rb ]; then
+				rake generate_secret_token
+			fi
+		fi
+		if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+			gosu redmine rake db:migrate
+		fi
+		
+		chown -R redmine:redmine files log public/plugin_assets
+		
+		# remove PID file to enable restarting the container
+		rm -f /usr/src/redmine/tmp/pids/server.pid
+		
+		if [ "$1" = 'passenger' ]; then
+			# Don't fear the reaper.
+			set -- tini -- "$@"
+		fi
+		
+		set -- gosu redmine "$@"
+		;;
+esac
+
+exec "$@"

--- a/3.2/passenger/Dockerfile
+++ b/3.2/passenger/Dockerfile
@@ -1,0 +1,15 @@
+FROM redmine:3.2
+
+ENV PASSENGER_VERSION 5.0.23
+RUN buildDeps=' \
+		make \
+	' \
+	&& set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& gem install passenger --version "$PASSENGER_VERSION" \
+	&& apt-get purge -y --auto-remove $buildDeps
+RUN set -x \
+	&& passenger-config install-agent \
+	&& passenger-config install-standalone-runtime
+
+CMD ["passenger", "start"]


### PR DESCRIPTION
Hello,
Redmine 3.1 and 3.2 are out now, and ready for release.  I've added folders and Dockerfiles for 3.1 and 3.2, as well as update the .travis.yml to test them.  I think the stackbrew script has to be updated as well, but I didn't touch that, since I'm not sure how it works.