### PR TITLE
Migrate plugins on startup of redmine

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -67,6 +67,9 @@ case "$1" in
 		
 		chown -R redmine:redmine files log public/plugin_assets
 		
+		# Make redmine aware of plugins
+		gosu redmine rake redmine:plugins:migrate
+		
 		# remove PID file to enable restarting the container
 		rm -f /usr/src/redmine/tmp/pids/server.pid
 		

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -67,8 +67,9 @@ case "$1" in
 		
 		chown -R redmine:redmine files log public/plugin_assets
 		
-		# Make redmine aware of plugins
-		gosu redmine rake redmine:plugins:migrate
+		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
+			gosu redmine rake redmine:plugins:migrate
+		fi
 		
 		# remove PID file to enable restarting the container
 		rm -f /usr/src/redmine/tmp/pids/server.pid


### PR DESCRIPTION
Redmine has a rake task to iterate all plugins and perform migration steps. The reference can be found [here](https://www.redmine.org/projects/redmine/wiki/Plugins).

This will make it easier to integrate Plugins in the docker container. The user only has to mount a host folder with all the required plugins to /usr/src/redmine/plugins. With this rake task in place, all steps for making the plugins available are taken, though there may still be dependencies for the plugin that have to be installed first. In order to automate dependency installation, it might be a good idea to expect a bash script with the same name as the plugin that can takes care of the dependencies.
