### PR TITLE
use "https" for communications with "www.redmine.org"

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /usr/src/redmine
 ENV REDMINE_VERSION 3.1.6
 ENV REDMINE_DOWNLOAD_MD5 ce846787e490ec5121b1c4b960a2a32b
 
-RUN curl -fSL "http://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
+RUN curl -fSL "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
 	&& echo "$REDMINE_DOWNLOAD_MD5 redmine.tar.gz" | md5sum -c - \
 	&& tar -xvf redmine.tar.gz --strip-components=1 \
 	&& rm redmine.tar.gz files/delete.me log/delete.me \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /usr/src/redmine
 ENV REDMINE_VERSION 3.2.3
 ENV REDMINE_DOWNLOAD_MD5 46178231093ed8a90e9d9b6c1e7d42b6
 
-RUN curl -fSL "http://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
+RUN curl -fSL "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
 	&& echo "$REDMINE_DOWNLOAD_MD5 redmine.tar.gz" | md5sum -c - \
 	&& tar -xvf redmine.tar.gz --strip-components=1 \
 	&& rm redmine.tar.gz files/delete.me log/delete.me \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /usr/src/redmine
 ENV REDMINE_VERSION 3.3.0
 ENV REDMINE_DOWNLOAD_MD5 0c0abb2d4efde455c3505d8caf01cb2d
 
-RUN curl -fSL "http://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
+RUN curl -fSL "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
 	&& echo "$REDMINE_DOWNLOAD_MD5 redmine.tar.gz" | md5sum -c - \
 	&& tar -xvf redmine.tar.gz --strip-components=1 \
 	&& rm redmine.tar.gz files/delete.me log/delete.me \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -46,7 +46,7 @@ WORKDIR /usr/src/redmine
 ENV REDMINE_VERSION %%REDMINE_VERSION%%
 ENV REDMINE_DOWNLOAD_MD5 %%REDMINE_DOWNLOAD_MD5%%
 
-RUN curl -fSL "http://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
+RUN curl -fSL "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" -o redmine.tar.gz \
 	&& echo "$REDMINE_DOWNLOAD_MD5 redmine.tar.gz" | md5sum -c - \
 	&& tar -xvf redmine.tar.gz --strip-components=1 \
 	&& rm redmine.tar.gz files/delete.me log/delete.me \


### PR DESCRIPTION
Redmine provides https for downloads, but links to http on their website.