### PR TITLE
Ruby version bump

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2-slim
+FROM ruby:2.3-slim
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r redmine && useradd -r -g redmine redmine


### PR DESCRIPTION
As ruby version 2.3 has no incompatible changes, this change makes sense.