### PR TITLE
Add redmine 3.3 alpine favor

### DIFF
--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -1,0 +1,94 @@
+FROM ruby:2.3-alpine
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN addgroup -S redmine && adduser -S -g redmine -H -D -s /bin/false redmine
+
+RUN apk add --no-cache \
+		openssl \
+		imagemagick \
+		mariadb-client-libs \
+		libpq \
+		sqlite-libs \
+		bash \
+		tzdata \
+		\
+		bzr \
+		git \
+		mercurial \
+		openssh-client \
+		subversion
+
+# grab tini for signal processing and zombie killing
+ENV TINI_VERSION v0.13.2
+RUN set -x \
+	&& apk add --no-cache --virtual .gnupg gnupg \
+	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-static-amd64" \
+	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-static-amd64.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+	&& apk del .gnupg \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
+	&& chmod +x /usr/local/bin/tini \
+	&& tini -h
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.10
+RUN set -x \
+	&& apk add --no-cache --virtual .gnupg gnupg \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& apk del .gnupg \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV RAILS_ENV production
+# Set RubyGems mirror site if official site is too slow
+WORKDIR /usr/src/redmine
+
+ENV REDMINE_VERSION 3.3.1
+ENV REDMINE_DOWNLOAD_MD5 cb8aab3e03cae7d21d003a307e51c176
+
+RUN wget -O redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz" \
+	&& echo "$REDMINE_DOWNLOAD_MD5  redmine.tar.gz" | md5sum -c - \
+	&& tar -xvf redmine.tar.gz \
+	&& find redmine-${REDMINE_VERSION} -name 'delete.me' -delete \
+	&& mv redmine-${REDMINE_VERSION}/* . \
+	&& rm -fr redmine-${REDMINE_VERSION}.tar.gz redmine-${REDMINE_VERSION} \
+	&& mkdir -p tmp/pdf ./public/plugin_assets \
+	&& chown -R redmine:redmine ./
+
+RUN buildDeps=' \
+		gcc \
+		imagemagick-dev \
+		libc-dev \
+		zlib-dev \
+		mariadb-dev \
+		postgresql-dev \
+		sqlite-dev \
+		make \
+		patch \
+	' \
+	&& set -ex \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& bundle install --without development test \
+	&& for adapter in mysql2 postgresql sqlite3; do \
+		echo "$RAILS_ENV:" > ./config/database.yml; \
+		echo "  adapter: $adapter" >> ./config/database.yml; \
+		bundle install --without development test; \
+	done \
+	&& rm -r ./config/database.yml "${HOME}/.bundle" "${HOME}/.gem" \
+	&& apk del .build-deps
+
+
+VOLUME /usr/src/redmine/files
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/3.3/alpine/docker-entrypoint.sh
+++ b/3.3/alpine/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -e
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+case "$1" in
+	rails|rake|passenger)
+		if [ ! -f './config/database.yml' ]; then
+			file_env 'REDMINE_DB_MYSQL'
+			file_env 'REDMINE_DB_POSTGRES'
+			
+			if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
+				export REDMINE_DB_MYSQL='mysql'
+			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
+				export REDMINE_DB_POSTGRES='postgres'
+			fi
+			
+			if [ "$REDMINE_DB_MYSQL" ]; then
+				adapter='mysql2'
+				host="$REDMINE_DB_MYSQL"
+				file_env 'REDMINE_DB_PORT' '3306'
+				file_env 'REDMINE_DB_USERNAME' "${MYSQL_ENV_MYSQL_USER:-root}"
+				file_env 'REDMINE_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+				file_env 'REDMINE_DB_DATABASE' "${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+				file_env 'REDMINE_DB_ENCODING' ''
+			elif [ "$REDMINE_DB_POSTGRES" ]; then
+				adapter='postgresql'
+				host="$REDMINE_DB_POSTGRES"
+				file_env 'REDMINE_DB_PORT' '5432'
+				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
+				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
+				file_env 'REDMINE_DB_ENCODING' 'utf8'
+			else
+				echo >&2
+				echo >&2 'warning: missing REDMINE_DB_MYSQL or REDMINE_DB_POSTGRES environment variables'
+				echo >&2
+				echo >&2 '*** Using sqlite3 as fallback. ***'
+				echo >&2
+				
+				adapter='sqlite3'
+				host='localhost'
+				file_env 'REDMINE_DB_PORT' ''
+				file_env 'REDMINE_DB_USERNAME' 'redmine'
+				file_env 'REDMINE_DB_PASSWORD' ''
+				file_env 'REDMINE_DB_DATABASE' 'sqlite/redmine.db'
+				file_env 'REDMINE_DB_ENCODING' 'utf8'
+				
+				mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
+				chown -R redmine:redmine "$(dirname "$REDMINE_DB_DATABASE")"
+			fi
+			
+			REDMINE_DB_ADAPTER="$adapter"
+			REDMINE_DB_HOST="$host"
+			echo "$RAILS_ENV:" > config/database.yml
+			for var in \
+				adapter \
+				host \
+				port \
+				username \
+				password \
+				database \
+				encoding \
+			; do
+				env="REDMINE_DB_${var^^}"
+				val="${!env}"
+				[ -n "$val" ] || continue
+				echo "  $var: \"$val\"" >> config/database.yml
+			done
+		fi
+		
+		# ensure the right database adapter is active in the Gemfile.lock
+                [ -n "${RUBYGEMS_MIRROR}" ] && bundle config mirror.https://rubygems.org "${RUBYGEMS_MIRROR}"
+		bundle install --without development test
+		
+		if [ ! -s config/secrets.yml ]; then
+			file_env 'REDMINE_SECRET_KEY_BASE'
+			if [ "$REDMINE_SECRET_KEY_BASE" ]; then
+				cat > 'config/secrets.yml' <<-YML
+					$RAILS_ENV:
+					  secret_key_base: "$REDMINE_SECRET_KEY_BASE"
+				YML
+			elif [ ! -f /usr/src/redmine/config/initializers/secret_token.rb ]; then
+				rake generate_secret_token
+			fi
+		fi
+		if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+			gosu redmine rake db:migrate
+		fi
+		
+		chown -R redmine:redmine files log public/plugin_assets
+		
+		# remove PID file to enable restarting the container
+		rm -f /usr/src/redmine/tmp/pids/server.pid
+		
+		if [ "$1" = 'passenger' ]; then
+			# Don't fear the reaper.
+			set -- tini -- "$@"
+		fi
+		
+		set -- gosu redmine "$@"
+		;;
+esac
+
+exec "$@"

--- a/3.3/passenger/alpine/Dockerfile
+++ b/3.3/passenger/alpine/Dockerfile
@@ -1,0 +1,23 @@
+FROM redmine:3.3-alpine
+
+ENV PASSENGER_VERSION 5.1.0
+RUN buildDeps=' \
+		make \
+		wget \
+		linux-headers \
+		gcc \
+		g++ \
+		openssl-dev \
+		zlib-dev \
+		curl-dev \
+		pcre-dev \
+	' \
+	&& set -x \
+	&& apk add --no-cache --virtual .build-deps ${buildDeps} \
+	&& gem install passenger --version "$PASSENGER_VERSION" \
+	&& passenger-config install-standalone-runtime \
+	&& passenger-config build-native-support \
+	&& rm -fr /tmp/passenger* ${HOME}/.[^.]* \
+	&& apk del .build-deps
+
+CMD ["passenger", "start"]

--- a/3.3/passenger/alpine/Dockerfile
+++ b/3.3/passenger/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM redmine:3.3-alpine
 
-ENV PASSENGER_VERSION 5.1.0
+ENV PASSENGER_VERSION 5.1.1
 RUN buildDeps=' \
 		make \
 		wget \


### PR DESCRIPTION
Add redmine `3.3` and `3.3-passenger` alpine favor.

Key modifications:
1. based on `ruby:2.3-alpine` image.
2. bump `tini` and `gksu` to the latest version.
2. delete `~/.{gem,bundle}` after bundle install, this can save about 10MB size.
3. Add a variable `RUBYGEM_MIRROR` for mirroring `https://rubygems.org`

TODO: rewrite `docker-entrypoint.sh` to use `/bin/sh` as she-bang, to delete the `bash` dependence.