### PR TITLE
Explicitly invoke "passenger-config download-nginx-engine" during image build time to avoid the runtime trying to download NGINX

### DIFF
--- a/3.1/passenger/Dockerfile
+++ b/3.1/passenger/Dockerfile
@@ -1,6 +1,7 @@
 FROM redmine:3.1
 
 ENV PASSENGER_VERSION 5.1.2
+
 RUN buildDeps=' \
 		make \
 	' \
@@ -8,8 +9,10 @@ RUN buildDeps=' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 	&& gem install passenger --version "$PASSENGER_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps
+
+# pre-download the PassengerAgent and the NGINX engine
 RUN set -x \
 	&& passenger-config install-agent \
-	&& passenger-config install-standalone-runtime
+	&& passenger-config download-nginx-engine
 
 CMD ["passenger", "start"]

--- a/3.2/passenger/Dockerfile
+++ b/3.2/passenger/Dockerfile
@@ -1,6 +1,7 @@
 FROM redmine:3.2
 
 ENV PASSENGER_VERSION 5.1.2
+
 RUN buildDeps=' \
 		make \
 	' \
@@ -8,8 +9,10 @@ RUN buildDeps=' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 	&& gem install passenger --version "$PASSENGER_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps
+
+# pre-download the PassengerAgent and the NGINX engine
 RUN set -x \
 	&& passenger-config install-agent \
-	&& passenger-config install-standalone-runtime
+	&& passenger-config download-nginx-engine
 
 CMD ["passenger", "start"]

--- a/3.3/passenger/Dockerfile
+++ b/3.3/passenger/Dockerfile
@@ -1,6 +1,7 @@
 FROM redmine:3.3
 
 ENV PASSENGER_VERSION 5.1.2
+
 RUN buildDeps=' \
 		make \
 	' \
@@ -8,8 +9,10 @@ RUN buildDeps=' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 	&& gem install passenger --version "$PASSENGER_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps
+
+# pre-download the PassengerAgent and the NGINX engine
 RUN set -x \
 	&& passenger-config install-agent \
-	&& passenger-config install-standalone-runtime
+	&& passenger-config download-nginx-engine
 
 CMD ["passenger", "start"]

--- a/Dockerfile-passenger.template
+++ b/Dockerfile-passenger.template
@@ -9,8 +9,10 @@ RUN buildDeps=' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
 	&& gem install passenger --version "$PASSENGER_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps
+
+# pre-download the PassengerAgent and the NGINX engine
 RUN set -x \
 	&& passenger-config install-agent \
-	&& passenger-config install-standalone-runtime
+	&& passenger-config download-nginx-engine
 
 CMD ["passenger", "start"]


### PR DESCRIPTION
Fixes #54