### PR TITLE
create and use db adapter specific Gemfile.lock files to fix issue #74

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -76,6 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
+		cp Gemfile.lock Gemfile.lock.${adapter}; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -76,7 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
-		cp Gemfile.lock Gemfile.lock.${adapter}; \
+		cp Gemfile.lock "Gemfile.lock.${adapter}"; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		bundle install --without development test
+		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				bundle exec ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -100,7 +100,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -76,6 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
+		cp Gemfile.lock Gemfile.lock.${adapter}; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -76,7 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
-		cp Gemfile.lock Gemfile.lock.${adapter}; \
+		cp Gemfile.lock "Gemfile.lock.${adapter}"; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		bundle install --without development test
+		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				bundle exec ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -100,7 +100,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -76,6 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
+		cp Gemfile.lock Gemfile.lock.${adapter}; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -76,7 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
-		cp Gemfile.lock Gemfile.lock.${adapter}; \
+		cp Gemfile.lock "Gemfile.lock.${adapter}"; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		bundle install --without development test
+		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				bundle exec ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -100,7 +100,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -76,6 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
+		cp Gemfile.lock Gemfile.lock.${adapter}; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -76,7 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
-		cp Gemfile.lock Gemfile.lock.${adapter}; \
+		cp Gemfile.lock "Gemfile.lock.${adapter}"; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		bundle install --without development test
+		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				bundle exec ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -100,7 +100,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -76,6 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
+		cp Gemfile.lock Gemfile.lock.${adapter}; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -76,7 +76,7 @@ RUN buildDeps=' \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \
-		cp Gemfile.lock Gemfile.lock.${adapter}; \
+		cp Gemfile.lock "Gemfile.lock.${adapter}"; \
 	done \
 	&& rm ./config/database.yml \
 	&& apt-get purge -y --auto-remove $buildDeps

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		bundle install --without development test
+		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				bundle exec ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -100,7 +100,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "/usr/src/redmine/Gemfile.lock.${adapter}" /usr/src/redmine/Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,7 +90,7 @@ case "$1" in
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
+		[ ! -z $adapter ] && cp /usr/src/redmine/Gemfile.lock.${adapter} /usr/src/redmine/Gemfile.lock
 		
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'


### PR DESCRIPTION
Reference issue #74 
- Update Dockerfile to create adapter specific `Gemfile.lock.${adapter}` file.
- Update `docker-entrypoint.sh` to copy adapter specific file to Gemfile.lock