### PR TITLE
Delete the process to get the database adapter.

### DIFF
--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -87,20 +87,10 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
-		else
-			# parse the database config to get the database adapter name
-			# so we can use the right Gemfile.lock
-			adapter="$(
-				bundle exec ruby -e "
-					require 'yaml'
-					conf = YAML.load_file('./config/database.yml')
-					puts conf['$RAILS_ENV']['adapter']
-				"
-			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "Gemfile.lock.${adapter}" Gemfile.lock
+		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -87,20 +87,10 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
-		else
-			# parse the database config to get the database adapter name
-			# so we can use the right Gemfile.lock
-			adapter="$(
-				bundle exec ruby -e "
-					require 'yaml'
-					conf = YAML.load_file('./config/database.yml')
-					puts conf['$RAILS_ENV']['adapter']
-				"
-			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "Gemfile.lock.${adapter}" Gemfile.lock
+		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -87,20 +87,10 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
-		else
-			# parse the database config to get the database adapter name
-			# so we can use the right Gemfile.lock
-			adapter="$(
-				bundle exec ruby -e "
-					require 'yaml'
-					conf = YAML.load_file('./config/database.yml')
-					puts conf['$RAILS_ENV']['adapter']
-				"
-			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "Gemfile.lock.${adapter}" Gemfile.lock
+		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,20 +87,10 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
-		else
-			# parse the database config to get the database adapter name
-			# so we can use the right Gemfile.lock
-			adapter="$(
-				bundle exec ruby -e "
-					require 'yaml'
-					conf = YAML.load_file('./config/database.yml')
-					puts conf['$RAILS_ENV']['adapter']
-				"
-			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		cp "Gemfile.lock.${adapter}" Gemfile.lock
+		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,10 +87,20 @@ case "$1" in
 				[ -n "$val" ] || continue
 				echo "  $var: \"$val\"" >> config/database.yml
 			done
+		else
+			# parse the database config to get the database adapter name
+			# so we can use the right Gemfile.lock
+			adapter="$(
+				ruby -e "
+					require 'yaml'
+					conf = YAML.load_file('./config/database.yml')
+					puts conf['$RAILS_ENV']['adapter']
+				"
+			)"
 		fi
 		
 		# ensure the right database adapter is active in the Gemfile.lock
-		[ ! -z $adapter ] && cp "Gemfile.lock.${adapter}" Gemfile.lock
+		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		


### PR DESCRIPTION
This `bundle exec` fails when a new plugin including Gemfile is placed.
Because `bundle install` has not been executed yet.
This code seems less necessary.
(#88 may be derived from the same cause)