### PR TITLE
Fix chmod to only add execute to directories

### DIFF
--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -121,7 +121,8 @@ case "$1" in
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
 		chown -R redmine:redmine files log public/plugin_assets
-		chmod -R 755 files log tmp public/plugin_assets
+		# directories 755, files 644:
+		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -121,7 +121,8 @@ case "$1" in
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
 		chown -R redmine:redmine files log public/plugin_assets
-		chmod -R 755 files log tmp public/plugin_assets
+		# directories 755, files 644:
+		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -121,7 +121,8 @@ case "$1" in
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
 		chown -R redmine:redmine files log public/plugin_assets
-		chmod -R 755 files log tmp public/plugin_assets
+		# directories 755, files 644:
+		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,7 +121,8 @@ case "$1" in
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
 		chown -R redmine:redmine files log public/plugin_assets
-		chmod -R 755 files log tmp public/plugin_assets
+		# directories 755, files 644:
+		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate


### PR DESCRIPTION
Fixes #94.

It has the same overall effect as the [docs](https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions), but only one permission change per file to be nicer to disks.
```console
chmod -R 755 files log tmp public/plugin_assets
find files log tmp public/plugin_assets -type f -exec chmod -x {} +
```