### PR TITLE
Add Microsoft SQL server adapter

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -68,14 +68,13 @@ RUN buildDeps=' \
 		make \
 		patch \
 		libgmp-dev \
-		build-essential \
 		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
+	&& for adapter in mysql2 postgresql sqlserver sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -67,12 +67,16 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
+		libgmp-dev \
+		build-essential \
+		wget \
+		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in mysql2 postgresql sqlite3; do \
+	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -69,7 +69,6 @@ RUN buildDeps=' \
 		patch \
 		libgmp-dev \
 		build-essential \
-		wget \
 		libc6-dev \
 	' \
 	&& set -ex \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -67,8 +67,6 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
-		libgmp-dev \
-		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -28,11 +28,14 @@ case "$1" in
 		if [ ! -f './config/database.yml' ]; then
 			file_env 'REDMINE_DB_MYSQL'
 			file_env 'REDMINE_DB_POSTGRES'
+			file_env 'REDMINE_DB_SQLSERVER'
 			
 			if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
+			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then
@@ -51,9 +54,17 @@ case "$1" in
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
+			elif [ "$REDMINE_DB_SQLSERVER" ]; then
+				adapter='sqlserver'
+				host="$REDMINE_DB_SQLSERVER"
+				file_env 'REDMINE_DB_PORT' '1433'
+				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
+				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
+				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
+				file_env 'REDMINE_DB_ENCODING' 'utf8'
 			else
 				echo >&2
-				echo >&2 'warning: missing REDMINE_DB_MYSQL or REDMINE_DB_POSTGRES environment variables'
+				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
 				echo >&2
 				echo >&2 '*** Using sqlite3 as fallback. ***'
 				echo >&2

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -34,8 +34,6 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
-				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -34,7 +34,7 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
 				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
@@ -58,10 +58,10 @@ case "$1" in
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
 				file_env 'REDMINE_DB_PORT' '1433'
-				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
-				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
-				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
-				file_env 'REDMINE_DB_ENCODING' 'utf8'
+				file_env 'REDMINE_DB_USERNAME' ''
+				file_env 'REDMINE_DB_PASSWORD' ''
+				file_env 'REDMINE_DB_DATABASE' ''
+				file_env 'REDMINE_DB_ENCODING' ''
 			else
 				echo >&2
 				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -68,14 +68,13 @@ RUN buildDeps=' \
 		make \
 		patch \
 		libgmp-dev \
-		build-essential \
 		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
+	&& for adapter in mysql2 postgresql sqlserver sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -67,12 +67,16 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
+		libgmp-dev \
+		build-essential \
+		wget \
+		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in mysql2 postgresql sqlite3; do \
+	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -69,7 +69,6 @@ RUN buildDeps=' \
 		patch \
 		libgmp-dev \
 		build-essential \
-		wget \
 		libc6-dev \
 	' \
 	&& set -ex \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -67,8 +67,6 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
-		libgmp-dev \
-		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -28,11 +28,14 @@ case "$1" in
 		if [ ! -f './config/database.yml' ]; then
 			file_env 'REDMINE_DB_MYSQL'
 			file_env 'REDMINE_DB_POSTGRES'
+			file_env 'REDMINE_DB_SQLSERVER'
 			
 			if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
+			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then
@@ -51,9 +54,17 @@ case "$1" in
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
+			elif [ "$REDMINE_DB_SQLSERVER" ]; then
+				adapter='sqlserver'
+				host="$REDMINE_DB_SQLSERVER"
+				file_env 'REDMINE_DB_PORT' '1433'				
+				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
+				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
+				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
+				file_env 'REDMINE_DB_ENCODING' 'utf8'
 			else
 				echo >&2
-				echo >&2 'warning: missing REDMINE_DB_MYSQL or REDMINE_DB_POSTGRES environment variables'
+				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
 				echo >&2
 				echo >&2 '*** Using sqlite3 as fallback. ***'
 				echo >&2

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -34,8 +34,6 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
-				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -34,7 +34,7 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
 				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
@@ -58,10 +58,10 @@ case "$1" in
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
 				file_env 'REDMINE_DB_PORT' '1433'
-				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
-				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
-				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
-				file_env 'REDMINE_DB_ENCODING' 'utf8'
+				file_env 'REDMINE_DB_USERNAME' ''
+				file_env 'REDMINE_DB_PASSWORD' ''
+				file_env 'REDMINE_DB_DATABASE' ''
+				file_env 'REDMINE_DB_ENCODING' ''
 			else
 				echo >&2
 				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'

--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -57,7 +57,7 @@ case "$1" in
 			elif [ "$REDMINE_DB_SQLSERVER" ]; then
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
-				file_env 'REDMINE_DB_PORT' '1433'				
+				file_env 'REDMINE_DB_PORT' '1433'
 				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -68,14 +68,13 @@ RUN buildDeps=' \
 		make \
 		patch \
 		libgmp-dev \
-		build-essential \
 		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
+	&& for adapter in mysql2 postgresql sqlserver sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -67,12 +67,16 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
+		libgmp-dev \
+		build-essential \
+		wget \
+		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in mysql2 postgresql sqlite3; do \
+	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -69,7 +69,6 @@ RUN buildDeps=' \
 		patch \
 		libgmp-dev \
 		build-essential \
-		wget \
 		libc6-dev \
 	' \
 	&& set -ex \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -67,8 +67,6 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
-		libgmp-dev \
-		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -28,11 +28,14 @@ case "$1" in
 		if [ ! -f './config/database.yml' ]; then
 			file_env 'REDMINE_DB_MYSQL'
 			file_env 'REDMINE_DB_POSTGRES'
+			file_env 'REDMINE_DB_SQLSERVER'
 			
 			if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
+			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then
@@ -51,9 +54,17 @@ case "$1" in
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
+			elif [ "$REDMINE_DB_SQLSERVER" ]; then
+				adapter='sqlserver'
+				host="$REDMINE_DB_SQLSERVER"
+				file_env 'REDMINE_DB_PORT' '1433'				
+				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
+				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
+				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
+				file_env 'REDMINE_DB_ENCODING' 'utf8'
 			else
 				echo >&2
-				echo >&2 'warning: missing REDMINE_DB_MYSQL or REDMINE_DB_POSTGRES environment variables'
+				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
 				echo >&2
 				echo >&2 '*** Using sqlite3 as fallback. ***'
 				echo >&2

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -34,8 +34,6 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
-				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -34,7 +34,7 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
 				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
@@ -58,10 +58,10 @@ case "$1" in
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
 				file_env 'REDMINE_DB_PORT' '1433'
-				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
-				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
-				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
-				file_env 'REDMINE_DB_ENCODING' 'utf8'
+				file_env 'REDMINE_DB_USERNAME' ''
+				file_env 'REDMINE_DB_PASSWORD' ''
+				file_env 'REDMINE_DB_DATABASE' ''
+				file_env 'REDMINE_DB_ENCODING' ''
 			else
 				echo >&2
 				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -57,7 +57,7 @@ case "$1" in
 			elif [ "$REDMINE_DB_SQLSERVER" ]; then
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
-				file_env 'REDMINE_DB_PORT' '1433'				
+				file_env 'REDMINE_DB_PORT' '1433'
 				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -67,12 +67,16 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
+		libgmp-dev \
+		build-essential \
+		wget \
+		libc6-dev \		
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in mysql2 postgresql sqlite3; do \
+	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,7 +14,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x036A9C25BF357DD4" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --fetch-key "http://pgp.mit.edu/pks/lookup?op=get&search=0x9A84159D7001A4E5" \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \
@@ -68,14 +68,13 @@ RUN buildDeps=' \
 		make \
 		patch \
 		libgmp-dev \
-		build-essential \
 		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& bundle install --without development test \
-	&& for adapter in sqlserver mysql2 postgresql sqlite3; do \
+	&& for adapter in mysql2 postgresql sqlserver sqlite3; do \
 		echo "$RAILS_ENV:" > ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 		bundle install --without development test; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -69,7 +69,6 @@ RUN buildDeps=' \
 		patch \
 		libgmp-dev \
 		build-essential \
-		wget \
 		libc6-dev \
 	' \
 	&& set -ex \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -70,7 +70,7 @@ RUN buildDeps=' \
 		libgmp-dev \
 		build-essential \
 		wget \
-		libc6-dev \		
+		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,7 +26,7 @@ RUN set -x \
 	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
 	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
 	&& chmod +x /usr/local/bin/tini \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -67,8 +67,6 @@ RUN buildDeps=' \
 		libsqlite3-dev \
 		make \
 		patch \
-		libgmp-dev \
-		libc6-dev \
 	' \
 	&& set -ex \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,11 +28,14 @@ case "$1" in
 		if [ ! -f './config/database.yml' ]; then
 			file_env 'REDMINE_DB_MYSQL'
 			file_env 'REDMINE_DB_POSTGRES'
+			file_env 'REDMINE_DB_SQLSERVER'
 			
 			if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
+			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then
@@ -51,9 +54,17 @@ case "$1" in
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
+			elif [ "$REDMINE_DB_SQLSERVER" ]; then
+				adapter='sqlserver'
+				host="$REDMINE_DB_SQLSERVER"
+				file_env 'REDMINE_DB_PORT' '1433'				
+				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
+				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
+				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
+				file_env 'REDMINE_DB_ENCODING' 'utf8'
 			else
 				echo >&2
-				echo >&2 'warning: missing REDMINE_DB_MYSQL or REDMINE_DB_POSTGRES environment variables'
+				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
 				echo >&2
 				echo >&2 '*** Using sqlite3 as fallback. ***'
 				echo >&2

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,8 +34,6 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
-				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
 			if [ "$REDMINE_DB_MYSQL" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,7 +34,7 @@ case "$1" in
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
-			elif [ "$POSTGRES_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
+			elif [ "$SQLSERVER_PORT_1433_TCP" ] && [ -z "$REDMINE_DB_SQLSERVER" ]; then
 				export REDMINE_DB_SQLSERVER='sqlserver'
 			fi
 			
@@ -58,10 +58,10 @@ case "$1" in
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
 				file_env 'REDMINE_DB_PORT' '1433'
-				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
-				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
-				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"
-				file_env 'REDMINE_DB_ENCODING' 'utf8'
+				file_env 'REDMINE_DB_USERNAME' ''
+				file_env 'REDMINE_DB_PASSWORD' ''
+				file_env 'REDMINE_DB_DATABASE' ''
+				file_env 'REDMINE_DB_ENCODING' ''
 			else
 				echo >&2
 				echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -57,7 +57,7 @@ case "$1" in
 			elif [ "$REDMINE_DB_SQLSERVER" ]; then
 				adapter='sqlserver'
 				host="$REDMINE_DB_SQLSERVER"
-				file_env 'REDMINE_DB_PORT' '1433'				
+				file_env 'REDMINE_DB_PORT' '1433'
 				file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_SQLSERVER_USER:-administrator}"
 				file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_SQLSERVER_PASSWORD}"
 				file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_SQLSERVER_DB:-${REDMINE_DB_USERNAME:-}}"


### PR DESCRIPTION
So, Redmine now has proper support for Microsoft SQL Server, which even runs on Linux and [Docker](https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker) now. I attempted to add support for this, and would appreciate feedback. I'm new to this stuff.

While building the Docker images, I had problems with `ha.pool.sks-keyservers.net` being slow and unreliable, so I'm also proposing changes to use the MIT server instead, which worked much more reliably for me.