### PR TITLE
 Fix permissions before migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ For more information about the official images process, see the [docker-library/
 
 ---
 
--	[Travis CI:  
+-	[Travis CI:
 	![build status badge](https://img.shields.io/travis/docker-library/redmine/master.svg)](https://travis-ci.org/docker-library/redmine/branches)
--	[Automated `update.sh`:  
+-	[Automated `update.sh`:
 	![build status badge](https://doi-janky.infosiftr.net/job/update.sh/job/redmine/badge/icon)](https://doi-janky.infosiftr.net/job/update.sh/job/redmine)
 
 | Build | Status | Badges | (per-arch) |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -113,6 +113,11 @@ case "$1" in
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
 		
+		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+		chown -R redmine:redmine files log public/plugin_assets
+		# directories 755, files 644:
+		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
+
 		if [ ! -s config/secrets.yml ]; then
 			file_env 'REDMINE_SECRET_KEY_BASE'
 			if [ "$REDMINE_SECRET_KEY_BASE" ]; then
@@ -127,11 +132,6 @@ case "$1" in
 		if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
 			gosu redmine rake db:migrate
 		fi
-		
-		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-		chown -R redmine:redmine files log public/plugin_assets
-		# directories 755, files 644:
-		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,13 +29,13 @@ case "$1" in
 			file_env 'REDMINE_DB_MYSQL'
 			file_env 'REDMINE_DB_POSTGRES'
 			file_env 'REDMINE_DB_SQLSERVER'
-			
+
 			if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
 				export REDMINE_DB_MYSQL='mysql'
 			elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
 				export REDMINE_DB_POSTGRES='postgres'
 			fi
-			
+
 			if [ "$REDMINE_DB_MYSQL" ]; then
 				adapter='mysql2'
 				host="$REDMINE_DB_MYSQL"
@@ -66,7 +66,7 @@ case "$1" in
 				echo >&2
 				echo >&2 '*** Using sqlite3 as fallback. ***'
 				echo >&2
-				
+
 				adapter='sqlite3'
 				host='localhost'
 				file_env 'REDMINE_DB_PORT' ''
@@ -74,11 +74,11 @@ case "$1" in
 				file_env 'REDMINE_DB_PASSWORD' ''
 				file_env 'REDMINE_DB_DATABASE' 'sqlite/redmine.db'
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
-				
+
 				mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
 				chown -R redmine:redmine "$(dirname "$REDMINE_DB_DATABASE")"
 			fi
-			
+
 			REDMINE_DB_ADAPTER="$adapter"
 			REDMINE_DB_HOST="$host"
 			echo "$RAILS_ENV:" > config/database.yml
@@ -107,12 +107,12 @@ case "$1" in
 				"
 			)"
 		fi
-		
+
 		# ensure the right database adapter is active in the Gemfile.lock
 		cp "Gemfile.lock.${adapter}" Gemfile.lock
 		# install additional gems for Gemfile.local and plugins
 		bundle check || bundle install --without development test
-		
+
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
 		chown -R redmine:redmine files log public/plugin_assets
 		# directories 755, files 644:
@@ -132,19 +132,19 @@ case "$1" in
 		if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
 			gosu redmine rake db:migrate
 		fi
-		
+
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate
 		fi
-		
+
 		# remove PID file to enable restarting the container
 		rm -f /usr/src/redmine/tmp/pids/server.pid
-		
+
 		if [ "$1" = 'passenger' ]; then
 			# Don't fear the reaper.
 			set -- tini -- "$@"
 		fi
-		
+
 		set -- gosu redmine "$@"
 		;;
 esac


### PR DESCRIPTION
This fixes permissions issues when you bind a host volume to `/usr/src/redmine/log` in order to have the logs outside.

```
Rails Error: Unable to access log file. Please ensure that /usr/src/redmine/log/production.log exists and is writable (ie, make it writable for user and group: chmod 0664 /usr/src/redmine/log/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
rake aborted!
Errno::EACCES: Permission denied @ rb_sysopen - /usr/src/redmine/log/redmine_helpdesk.log
/usr/src/redmine/plugins/redmine_contacts_helpdesk/lib/redmine_helpdesk.rb:36:in `new'
```