### PR TITLE
Only chown things in the entrypoint that are not already owned by redmine

### DIFF
--- a/3.3/docker-entrypoint.sh
+++ b/3.3/docker-entrypoint.sh
@@ -76,7 +76,7 @@ case "$1" in
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
 				
 				mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
-				chown -R redmine:redmine "$(dirname "$REDMINE_DB_DATABASE")"
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
 			fi
 			
 			REDMINE_DB_ADAPTER="$adapter"
@@ -129,9 +129,10 @@ case "$1" in
 		fi
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-		chown -R redmine:redmine files log public/plugin_assets
+		find files log public/plugin_assets \! -user redmine -exec chown redmine:redmine '{}' +
 		# directories 755, files 644:
-		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
+		find files log tmp public/plugin_assets -type d \! -perm 755 -exec chmod 755 '{}' +
+		find files log tmp public/plugin_assets -type f \! -perm 644 -exec chmod 644 '{}' +
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -76,7 +76,7 @@ case "$1" in
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
 				
 				mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
-				chown -R redmine:redmine "$(dirname "$REDMINE_DB_DATABASE")"
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
 			fi
 			
 			REDMINE_DB_ADAPTER="$adapter"
@@ -129,9 +129,10 @@ case "$1" in
 		fi
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-		chown -R redmine:redmine files log public/plugin_assets
+		find files log public/plugin_assets \! -user redmine -exec chown redmine:redmine '{}' +
 		# directories 755, files 644:
-		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
+		find files log tmp public/plugin_assets -type d \! -perm 755 -exec chmod 755 '{}' +
+		find files log tmp public/plugin_assets -type f \! -perm 644 -exec chmod 644 '{}' +
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,7 +76,7 @@ case "$1" in
 				file_env 'REDMINE_DB_ENCODING' 'utf8'
 				
 				mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
-				chown -R redmine:redmine "$(dirname "$REDMINE_DB_DATABASE")"
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
 			fi
 			
 			REDMINE_DB_ADAPTER="$adapter"
@@ -129,9 +129,10 @@ case "$1" in
 		fi
 		
 		# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-		chown -R redmine:redmine files log public/plugin_assets
+		find files log public/plugin_assets \! -user redmine -exec chown redmine:redmine '{}' +
 		# directories 755, files 644:
-		chmod -R ugo-x,u+rwX,go+rX,go-w files log tmp public/plugin_assets
+		find files log tmp public/plugin_assets -type d \! -perm 755 -exec chmod 755 '{}' +
+		find files log tmp public/plugin_assets -type f \! -perm 644 -exec chmod 644 '{}' +
 		
 		if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
 			gosu redmine rake redmine:plugins:migrate


### PR DESCRIPTION
Also only `chmod` when not it is not the right permissions. This removes the `ugo-x,u+rwX,go+rX,go-w`, which makes it much easier to understand.

This does not change the `chown` to user only like the mariadb and percona changes do since the upstream [docs](https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions) recommend `chown redmine:redmine`.  Should I expand the finds to fix group owner too?

Same as https://github.com/docker-library/rabbitmq/pull/281, https://github.com/docker-library/mariadb/pull/203, https://github.com/docker-library/percona/pull/69