### PR TITLE
Pre-create /home/redmine and set wide permissions on it

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -67,6 +67,15 @@ RUN set -eux; \
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine
 
+# https://github.com/docker-library/redmine/issues/138#issuecomment-438834176
+# (bundler needs this for running as an arbitrary user)
+ENV HOME /home/redmine
+RUN set -eux; \
+	[ ! -d "$HOME" ]; \
+	mkdir -p "$HOME"; \
+	chown redmine:redmine "$HOME"; \
+	chmod 1777 "$HOME"
+
 ENV REDMINE_VERSION 3.3.8
 ENV REDMINE_DOWNLOAD_MD5 6ca9284fa1c3571f6c83dd0e0d0fec1b
 

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -67,6 +67,15 @@ RUN set -eux; \
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine
 
+# https://github.com/docker-library/redmine/issues/138#issuecomment-438834176
+# (bundler needs this for running as an arbitrary user)
+ENV HOME /home/redmine
+RUN set -eux; \
+	[ ! -d "$HOME" ]; \
+	mkdir -p "$HOME"; \
+	chown redmine:redmine "$HOME"; \
+	chmod 1777 "$HOME"
+
 ENV REDMINE_VERSION 3.4.6
 ENV REDMINE_DOWNLOAD_MD5 5f4993446ecf25782f469763c0d32ea1
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -67,6 +67,15 @@ RUN set -eux; \
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine
 
+# https://github.com/docker-library/redmine/issues/138#issuecomment-438834176
+# (bundler needs this for running as an arbitrary user)
+ENV HOME /home/redmine
+RUN set -eux; \
+	[ ! -d "$HOME" ]; \
+	mkdir -p "$HOME"; \
+	chown redmine:redmine "$HOME"; \
+	chmod 1777 "$HOME"
+
 ENV REDMINE_VERSION %%REDMINE_VERSION%%
 ENV REDMINE_DOWNLOAD_MD5 %%REDMINE_DOWNLOAD_MD5%%
 


### PR DESCRIPTION
This should fix #138, and _might_ fix #137 -- more testing required (not 100% sure we've completely reproduced all the failure modes we're seeing in #137, especially around `/usr/local/bundle/config`).

@wglambert what's the easiest way for me to help you test this and make sure it fixes at least the things you managed to reproduce?  Do you need me to push it somewhere, or can you build it from here?

I guess realistically, anyone looking to help test this should be able to do so with something like this:

```console
$ docker build --pull -t redmine:3.4 https://github.com/infosiftr/redmine.git#home-redmine:3.4
```

(and then use that now-locally-built `redmine:3.4` image in your `docker-compose.yml`, etc.)