### PR TITLE
Update to Alpine 3.12 and drop bzr

### DIFF
--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.11
+FROM ruby:2.6-alpine3.12
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
@@ -14,7 +14,6 @@ RUN set -eux; \
 		tzdata \
 		wget \
 		\
-		bzr \
 		git \
 		mercurial \
 		openssh-client \

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.11
+FROM ruby:2.6-alpine3.12
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
@@ -14,7 +14,6 @@ RUN set -eux; \
 		tzdata \
 		wget \
 		\
-		bzr \
 		git \
 		mercurial \
 		openssh-client \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,4 @@
-FROM ruby:%%RUBY_VERSION%%-alpine3.11
+FROM ruby:%%RUBY_VERSION%%-alpine3.12
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
@@ -14,7 +14,6 @@ RUN set -eux; \
 		tzdata \
 		wget \
 		\
-		bzr \
 		git \
 		mercurial \
 		openssh-client \


### PR DESCRIPTION
[bazaar](https://bazaar.canonical.com/) has been replaced by [breezy](https://www.breezy-vcs.org/) which hasn't it made out of [testing](https://pkgs.alpinelinux.org/packages?name=breezy&branch=edge) for 3.13.

This was the only blocker for upgrading Alpine.