### PR TITLE
Use sha256 for checksumming

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -39,11 +39,11 @@ RUN set -eux; \
 	chmod 1777 "$HOME"
 
 ENV REDMINE_VERSION %%REDMINE_VERSION%%
-ENV REDMINE_DOWNLOAD_MD5 %%REDMINE_DOWNLOAD_MD5%%
+ENV REDMINE_DOWNLOAD_SHA256 %%REDMINE_DOWNLOAD_SHA256%%
 
 RUN set -eux; \
 	wget -O redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
-	echo "$REDMINE_DOWNLOAD_MD5 *redmine.tar.gz" | md5sum -c -; \
+	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -79,11 +79,11 @@ RUN set -eux; \
 	chmod 1777 "$HOME"
 
 ENV REDMINE_VERSION %%REDMINE_VERSION%%
-ENV REDMINE_DOWNLOAD_MD5 %%REDMINE_DOWNLOAD_MD5%%
+ENV REDMINE_DOWNLOAD_SHA256 %%REDMINE_DOWNLOAD_SHA256%%
 
 RUN set -eux; \
 	wget -O redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
-	echo "$REDMINE_DOWNLOAD_MD5 *redmine.tar.gz" | md5sum -c -; \
+	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \

--- a/update.sh
+++ b/update.sh
@@ -22,7 +22,7 @@ passenger="$(wget -qO- 'https://rubygems.org/api/v1/gems/passenger.json' | sed -
 
 for version in "${versions[@]}"; do
 	fullVersion="$(echo $versionsPage | sed -r "s/.*($version\.[0-9]+)\.tar\.gz[^.].*/\1/" | sort -V | tail -1)"
-	md5="$(wget -qO- "$relasesUrl/redmine-$fullVersion.tar.gz.md5" | cut -d' ' -f1)"
+	sha256="$(wget -qO- "$relasesUrl/redmine-$fullVersion.tar.gz.sha256" | cut -d' ' -f1)"
 
 	rubyVersion="${rubyVersions[$version]:-$defaultRubyVersion}"
 
@@ -32,7 +32,7 @@ for version in "${versions[@]}"; do
 		-r
 		-e 's/%%REDMINE_VERSION%%/'"$fullVersion"'/'
 		-e 's/%%RUBY_VERSION%%/'"$rubyVersion"'/'
-		-e 's/%%REDMINE_DOWNLOAD_MD5%%/'"$md5"'/'
+		-e 's/%%REDMINE_DOWNLOAD_SHA256%%/'"$sha256"'/'
 		-e 's/%%REDMINE%%/redmine:'"$version"'/'
 		-e 's/%%PASSENGER_VERSION%%/'"$passenger"'/'
 	)


### PR DESCRIPTION
md5 is insecure, and for the latest releases only .sha256 files are
provided on redmine.org, thus the update.sh fails when downloading .md5
files.