### PR TITLE
Avoid glibc dependency

### DIFF
--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -53,7 +53,7 @@ RUN set -eux; \
 	chmod -R ugo=rwX config db sqlite; \
 	find log tmp -type d -exec chmod 1777 '{}' +
 
-# build for musl-libc, not glibc
+# build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1
 RUN set -eux; \
 	\

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -53,6 +53,8 @@ RUN set -eux; \
 	chmod -R ugo=rwX config db sqlite; \
 	find log tmp -type d -exec chmod 1777 '{}' +
 
+# build for musl-libc, not glibc
+ENV BUNDLE_FORCE_RUBY_PLATFORM 1
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -88,14 +88,10 @@ RUN set -eux; \
 	rm /usr/local/bundle/gems/rbpdf-font-1.19.*/lib/fonts/ttf2ufm/ttf2ufm; \
 	\
 	runDeps="$( \
-		find /usr/local -type f -executable -exec ldd '{}' ';' \
-			| awk '/=>/ { print $(NF-1) }' \
-			| sort -u \
-			| grep -v '^/usr/local/' \
-			| xargs -rn1 basename \
-			| grep -v 'ld-musl-' \
-			| sed -e 's/^/so:/' \
-			| sort -u \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/bundle/gems \
+		| tr ',' '\n' \
+		| sort -u \
+		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
 	apk del --no-network .build-deps

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -54,6 +54,8 @@ RUN set -eux; \
 	chmod -R ugo=rwX config db sqlite; \
 	find log tmp -type d -exec chmod 1777 '{}' +
 
+# build for musl-libc, not glibc
+ENV BUNDLE_FORCE_RUBY_PLATFORM 1
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 	chmod -R ugo=rwX config db sqlite; \
 	find log tmp -type d -exec chmod 1777 '{}' +
 
-# build for musl-libc, not glibc
+# build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1
 RUN set -eux; \
 	\

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -87,14 +87,10 @@ RUN set -eux; \
 	rm /usr/local/bundle/gems/rbpdf-font-1.19.*/lib/fonts/ttf2ufm/ttf2ufm; \
 	\
 	runDeps="$( \
-		find /usr/local -type f -executable -exec ldd '{}' ';' \
-			| awk '/=>/ { print $(NF-1) }' \
-			| sort -u \
-			| grep -v '^/usr/local/' \
-			| xargs -rn1 basename \
-			| grep -v 'ld-musl-' \
-			| sed -e 's/^/so:/' \
-			| sort -u \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/bundle/gems \
+		| tr ',' '\n' \
+		| sort -u \
+		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
 	apk del --no-network .build-deps

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -54,6 +54,8 @@ RUN set -eux; \
 	chmod -R ugo=rwX config db sqlite; \
 	find log tmp -type d -exec chmod 1777 '{}' +
 
+# build for musl-libc, not glibc
+ENV BUNDLE_FORCE_RUBY_PLATFORM 1
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -54,7 +54,7 @@ RUN set -eux; \
 	chmod -R ugo=rwX config db sqlite; \
 	find log tmp -type d -exec chmod 1777 '{}' +
 
-# build for musl-libc, not glibc
+# build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1
 RUN set -eux; \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -89,14 +89,10 @@ RUN set -eux; \
 	rm /usr/local/bundle/gems/rbpdf-font-1.19.*/lib/fonts/ttf2ufm/ttf2ufm; \
 	\
 	runDeps="$( \
-		find /usr/local -type f -executable -exec ldd '{}' ';' \
-			| awk '/=>/ { print $(NF-1) }' \
-			| sort -u \
-			| grep -v '^/usr/local/' \
-			| xargs -rn1 basename \
-			| grep -v 'ld-musl-' \
-			| sed -e 's/^/so:/' \
-			| sort -u \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/bundle/gems \
+		| tr ',' '\n' \
+		| sort -u \
+		| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
 	apk del --no-network .build-deps


### PR DESCRIPTION
The main issue is that nokogiri tries to install the `x86_64-linux` binary which is linked to glibc. https://github.com/sparklemotion/nokogiri/issues/2075
This does not work well on musl-libc based systems like Alpine. There might be [a fix at some point in the future](https://github.com/rubygems/rubygems/issues/3174) but up to now it still breaks.