### PR TITLE
Allow ImageMagick to read ghostscript

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -25,6 +25,7 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
+	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -25,7 +25,6 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
-	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -26,8 +26,8 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
-# allow imagemagick to use ghostscript (4.1+)
-	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
+# allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
+	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -26,6 +26,8 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
+# allow imagemagick to use ghostscript (4.1+)
+	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -26,8 +26,8 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
-# allow imagemagick to use ghostscript (4.1+)
-	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
+# allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
+	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -26,6 +26,8 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
+# allow imagemagick to use ghostscript (4.1+)
+	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -26,8 +26,8 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
-# allow imagemagick to use ghostscript (4.1+)
-	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
+# allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
+	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -26,6 +26,8 @@ RUN set -eux; \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
+# allow imagemagick to use ghostscript (4.1+)
+	sed -Ei 's@(<policy domain="coder" rights=)"none"( pattern="PDF"\s*/>)@\1"read"\2@' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production

--- a/update.sh
+++ b/update.sh
@@ -45,6 +45,7 @@ for version in "${versions[@]}"; do
 	if [ "$version" = 4.0 ]; then
 		commonSedArgs+=(
 			-e '/ghostscript /d'
+			-e '\!ImageMagick-6/policy\.xml!d'
 		)
 		alpineSedArgs+=(
 			-e 's/imagemagick/imagemagick6/g'


### PR DESCRIPTION
* Fixes #225.
* The previously failing attachment-related tests are now passing.
* There are no other tests failing (at least on our CI based on this image).