### PR TITLE
shared-mime-info not needed anymore

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -20,53 +20,12 @@ RUN set -eux; \
 # and "ghostscript" for creating PDF thumbnails (in 4.1+)
 		gsfonts \
 		imagemagick \
-		\
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
+# grab gosu for easy step-down from root
+		gosu \
+# grab tini for signal processing and zombie killing
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		dirmngr \
-		gnupg \
-	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	\
-# grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-	export GOSU_VERSION='1.12'; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu nobody true; \
-	\
-# grab tini for signal processing and zombie killing
-# https://github.com/krallin/tini/releases
-	export TINI_VERSION='0.19.0'; \
-	wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch"; \
-	wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5; \
-	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/tini.asc; \
-	chmod +x /usr/local/bin/tini; \
-	tini -h; \
-	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -23,8 +23,6 @@ RUN set -eux; \
 # and "ghostscript" for creating PDF thumbnails (in 4.1+)
 		ghostscript-fonts \
 		imagemagick6 \
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
 	;
 
 ENV RAILS_ENV production

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -21,53 +21,12 @@ RUN set -eux; \
 		ghostscript \
 		gsfonts \
 		imagemagick \
-		\
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
+# grab gosu for easy step-down from root
+		gosu \
+# grab tini for signal processing and zombie killing
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		dirmngr \
-		gnupg \
-	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	\
-# grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-	export GOSU_VERSION='1.12'; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu nobody true; \
-	\
-# grab tini for signal processing and zombie killing
-# https://github.com/krallin/tini/releases
-	export TINI_VERSION='0.19.0'; \
-	wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch"; \
-	wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5; \
-	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/tini.asc; \
-	chmod +x /usr/local/bin/tini; \
-	tini -h; \
-	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -24,8 +24,6 @@ RUN set -eux; \
 		ghostscript \
 		ghostscript-fonts \
 		imagemagick \
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
 	;
 
 ENV RAILS_ENV production

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -21,53 +21,12 @@ RUN set -eux; \
 		ghostscript \
 		gsfonts \
 		imagemagick \
-		\
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
+# grab gosu for easy step-down from root
+		gosu \
+# grab tini for signal processing and zombie killing
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		dirmngr \
-		gnupg \
-	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	\
-# grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-	export GOSU_VERSION='1.12'; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu nobody true; \
-	\
-# grab tini for signal processing and zombie killing
-# https://github.com/krallin/tini/releases
-	export TINI_VERSION='0.19.0'; \
-	wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch"; \
-	wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5; \
-	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/tini.asc; \
-	chmod +x /usr/local/bin/tini; \
-	tini -h; \
-	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine

--- a/4.2/alpine/Dockerfile
+++ b/4.2/alpine/Dockerfile
@@ -24,8 +24,6 @@ RUN set -eux; \
 		ghostscript \
 		ghostscript-fonts \
 		imagemagick \
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
 	;
 
 ENV RAILS_ENV production

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -24,8 +24,6 @@ RUN set -eux; \
 		ghostscript \
 		ghostscript-fonts \
 		imagemagick \
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
 	;
 
 ENV RAILS_ENV production

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -21,53 +21,12 @@ RUN set -eux; \
 		ghostscript \
 		gsfonts \
 		imagemagick \
-		\
-# https://github.com/docker-library/ruby/issues/344
-		shared-mime-info \
+# grab gosu for easy step-down from root
+		gosu \
+# grab tini for signal processing and zombie killing
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		dirmngr \
-		gnupg \
-	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	\
-# grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-	export GOSU_VERSION='1.12'; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu nobody true; \
-	\
-# grab tini for signal processing and zombie killing
-# https://github.com/krallin/tini/releases
-	export TINI_VERSION='0.19.0'; \
-	wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch"; \
-	wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5; \
-	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini; \
-	gpgconf --kill all; \
-	rm -r "$GNUPGHOME" /usr/local/bin/tini.asc; \
-	chmod +x /usr/local/bin/tini; \
-	tini -h; \
-	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine


### PR DESCRIPTION
rails 5.2.5 got rid of mimemagic dependency:
https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/

use packaged gosu & tini for debian based images