### PR TITLE
Update to 4.2.4 and 4.1.6 security releases

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -43,12 +43,13 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 4.1.5
-ENV REDMINE_DOWNLOAD_SHA256 624dfeab7db5cda35a03d791b5fa83a836717ca280856c51cd089ed638f8678e
+ENV REDMINE_VERSION 4.1.6
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/attachments/download/28858/redmine-4.1.6.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 b75dacdd61745284c433480c5efd9139d9da965e26ade4f6dc0d6d33be5410a2
 
 RUN set -eux; \
 # if we use wget here, we get certificate issues (https://github.com/docker-library/redmine/pull/249#issuecomment-984176479)
-	curl -fL -o redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
+	curl -fL -o redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -39,11 +39,12 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 4.1.5
-ENV REDMINE_DOWNLOAD_SHA256 624dfeab7db5cda35a03d791b5fa83a836717ca280856c51cd089ed638f8678e
+ENV REDMINE_VERSION 4.1.6
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/attachments/download/28858/redmine-4.1.6.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 b75dacdd61745284c433480c5efd9139d9da965e26ade4f6dc0d6d33be5410a2
 
 RUN set -eux; \
-	wget -O redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
+	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -43,12 +43,13 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 4.2.3
-ENV REDMINE_DOWNLOAD_SHA256 72f633dc954217948558889ca85325fe6410cd18a2d8b39358e5d75932a47a0c
+ENV REDMINE_VERSION 4.2.4
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/attachments/download/28862/redmine-4.2.4.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 7f50fd4a6cf1c1e48091a87696b813ba264e11f04dec67fb006858a1b49a5c7d
 
 RUN set -eux; \
 # if we use wget here, we get certificate issues (https://github.com/docker-library/redmine/pull/249#issuecomment-984176479)
-	curl -fL -o redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
+	curl -fL -o redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \

--- a/4.2/alpine/Dockerfile
+++ b/4.2/alpine/Dockerfile
@@ -39,11 +39,12 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 4.2.3
-ENV REDMINE_DOWNLOAD_SHA256 72f633dc954217948558889ca85325fe6410cd18a2d8b39358e5d75932a47a0c
+ENV REDMINE_VERSION 4.2.4
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/attachments/download/28862/redmine-4.2.4.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 7f50fd4a6cf1c1e48091a87696b813ba264e11f04dec67fb006858a1b49a5c7d
 
 RUN set -eux; \
-	wget -O redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
+	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -40,10 +40,11 @@ RUN set -eux; \
 	chmod 1777 "$HOME"
 
 ENV REDMINE_VERSION %%REDMINE_VERSION%%
+ENV REDMINE_DOWNLOAD_URL %%REDMINE_DOWNLOAD_URL%%
 ENV REDMINE_DOWNLOAD_SHA256 %%REDMINE_DOWNLOAD_SHA256%%
 
 RUN set -eux; \
-	wget -O redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
+	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -44,11 +44,12 @@ RUN set -eux; \
 	chmod 1777 "$HOME"
 
 ENV REDMINE_VERSION %%REDMINE_VERSION%%
+ENV REDMINE_DOWNLOAD_URL %%REDMINE_DOWNLOAD_URL%%
 ENV REDMINE_DOWNLOAD_SHA256 %%REDMINE_DOWNLOAD_SHA256%%
 
 RUN set -eux; \
 # if we use wget here, we get certificate issues (https://github.com/docker-library/redmine/pull/249#issuecomment-984176479)
-	curl -fL -o redmine.tar.gz "https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz"; \
+	curl -fL -o redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \


### PR DESCRIPTION
See https://www.redmine.org/news/134

Closes #256

(I don't _love_ the implementation here, especially the sha256 scraping, but it'll do for now so we can get this security release out.)