### PR TITLE
Add "xz" to fix build on many architectures

### DIFF
--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -73,6 +73,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		make \
 		patch \
+		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -73,6 +73,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		make \
 		patch \
+		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -73,6 +73,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		make \
 		patch \
+		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\


### PR DESCRIPTION
Tested and verified on `arm32v7` (but the failures are similar across at least `arm32v5`, `ppc64le`, `s390x`).