### PR TITLE
Update entrypoint to combine "find" invocations

### DIFF
--- a/4.2/alpine/Dockerfile
+++ b/4.2/alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN set -eux; \
 	apk add --no-cache \
 		bash \
 		ca-certificates \
+		findutils \
 		su-exec \
 		tini \
 		tzdata \

--- a/5.0/alpine/Dockerfile
+++ b/5.0/alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN set -eux; \
 	apk add --no-cache \
 		bash \
 		ca-certificates \
+		findutils \
 		su-exec \
 		tini \
 		tzdata \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -9,6 +9,7 @@ RUN set -eux; \
 	apk add --no-cache \
 		bash \
 		ca-certificates \
+		findutils \
 		su-exec \
 		tini \
 		tzdata \


### PR DESCRIPTION
This should result in at most two invocations of `find` (as opposed to five), on a set of directories that might include a really huge amount of small files.

Refs #268