### PR TITLE
Use ruby-3.2 for redmine-5.1

### DIFF
--- a/5.1/alpine3.18/Dockerfile
+++ b/5.1/alpine3.18/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM ruby:3.1-alpine3.18
+FROM ruby:3.2-alpine3.18
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM ruby:3.1-slim-bookworm
+FROM ruby:3.2-slim-bookworm
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned

--- a/versions.json
+++ b/versions.json
@@ -18,7 +18,7 @@
     "debian": "bookworm",
     "downloadUrl": "https://www.redmine.org/releases/redmine-5.1.1.tar.gz",
     "ruby": {
-      "version": "3.1"
+      "version": "3.2"
     },
     "sha256": "edf3095746effd04ad5140681d618f5fa8d06be09c47b6f8b615dcad0b753e6e",
     "variants": [

--- a/versions.sh
+++ b/versions.sh
@@ -17,8 +17,9 @@ declare -A alpineVersions=(
 	#[5.0]='3.16'
 )
 # see https://www.redmine.org/projects/redmine/wiki/redmineinstall
-defaultRubyVersion='3.1'
+defaultRubyVersion='3.2'
 declare -A rubyVersions=(
+	[5.0]='3.1'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Redmine 5.1 can use Ruby 3.2 :tada:: https://www.redmine.org/projects/redmine/wiki/redmineinstall

This pull-request makes us using redmine-5.1 on ruby-3.2.

- Mainly changes are ~~7d1d1f1c4ab5de3d632f5eacea93fb4e841f960d~~ 58b7f5e708ad8c7c08dbb32912888cd52a572103 .
- Other commit ( ~~19a761216ef803244f8a98d0474d697f3f473f01~~ dd3e3aa0bfed505380eb13e814dce0dddb55cf80 ) runs `./update.sh` .
