### PR TITLE
Add missing build dependency to fix 5.1 builds on s390x and ppc64le

### DIFF
--- a/5.0/bookworm/Dockerfile
+++ b/5.0/bookworm/Dockerfile
@@ -79,6 +79,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		make \
 		patch \
+		pkgconf \
 		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -79,6 +79,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		make \
 		patch \
+		pkgconf \
 		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -73,6 +73,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		make \
 		patch \
+		pkgconf \
 		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
Build test with `--platform=linux/s390x` worked successfully (and reproduced the failure when unchanged).

Failing build output:
```console
+ gosu redmine bundle install --jobs 16
...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/sqlite3-1.6.9/ext/sqlite3
/usr/local/bin/ruby extconf.rb
Building sqlite3-ruby using packaged sqlite3.
Extracting sqlite-autoconf-3440200.tar.gz into
tmp/powerpc64le-linux-gnu/ports/sqlite3/3.44.2... OK
Running 'configure' for sqlite3 3.44.2... OK
Running 'compile' for sqlite3 3.44.2... OK
Running 'install' for sqlite3 3.44.2... OK
Activating sqlite3 3.44.2 (from
/usr/local/bundle/gems/sqlite3-1.6.9/ports/powerpc64le-linux-gnu/sqlite3/3.44.2)...

Could not configure the build properly (pkg_config). Please install either the
`pkg-config` utility or the `pkg-config` rubygem.

*** extconf.rb failed ***
```