### PR TITLE
Fix mips64le build errors

### DIFF
--- a/5.0/bookworm/Dockerfile
+++ b/5.0/bookworm/Dockerfile
@@ -105,6 +105,8 @@ RUN set -eux; \
 		gcc \
 		libpq-dev \
 		libsqlite3-dev \
+		libxml2-dev \
+		libxslt-dev \
 		make \
 		patch \
 		pkgconf \
@@ -124,6 +126,8 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
+	gosu redmine bundle config build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user

--- a/5.0/bookworm/Dockerfile
+++ b/5.0/bookworm/Dockerfile
@@ -28,14 +28,42 @@ RUN set -eux; \
 		ghostscript \
 		gsfonts \
 		imagemagick \
-# grab gosu for easy step-down from root
-		gosu \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
 # allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
 	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -105,6 +105,8 @@ RUN set -eux; \
 		gcc \
 		libpq-dev \
 		libsqlite3-dev \
+		libxml2-dev \
+		libxslt-dev \
 		make \
 		patch \
 		pkgconf \
@@ -124,6 +126,8 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
+	gosu redmine bundle config build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -28,14 +28,42 @@ RUN set -eux; \
 		ghostscript \
 		gsfonts \
 		imagemagick \
-# grab gosu for easy step-down from root
-		gosu \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
 # allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
 	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -22,14 +22,42 @@ RUN set -eux; \
 		ghostscript \
 		gsfonts \
 		imagemagick \
-# grab gosu for easy step-down from root
-		gosu \
 # grab tini for signal processing and zombie killing
 		tini \
 	; \
 # allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
 	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
 
 ENV RAILS_ENV production
 WORKDIR /usr/src/redmine

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -99,6 +99,8 @@ RUN set -eux; \
 		gcc \
 		libpq-dev \
 		libsqlite3-dev \
+		libxml2-dev \
+		libxslt-dev \
 		make \
 		patch \
 		pkgconf \
@@ -118,6 +120,8 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
+	gosu redmine bundle config build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user


### PR DESCRIPTION
The `mips64le` `gosu` binary from Debian bookworm packages fails to run with this error:
```console
fatal error: AllThreadsSyscall6 results differ between threads; runtime corrupted
```
aka: https://github.com/golang/go/issues/56426. See also https://github.com/tianon/gosu/pull/121

This also adds `libxml2-dev` and `libxslt-dev` to fix the `nokogiri` gem on architectures where there isn't a native gem (like mips64le) and `nokogiri` attempts to build its own vendored versions of them. The two lib packages and deps will be correctly kept or purged by the `apt-mark` dance.

```console
Building Nokogiri with a packaged version of libxml2-2.11.6.
Configuration options: --host\=mips64el-unknown-linux-abi64 --enable-static
--disable-shared
--libdir\=/usr/local/bundle/gems/nokogiri-1.15.5/ports/mips64el-linux-abi64/libxml2/2.11.6/lib
--with-iconv\=yes --disable-dependency-tracking --without-python
--without-readline --with-c14n --with-debug --with-threads --disable-shared
--enable-static CPPFLAGS\= CFLAGS\=-O2\ -U_FORTIFY_SOURCE\ -g\ -fPIC
...
Running 'configure' for libxml2 2.11.6... ERROR. Please review logs to see what
happened:
----- contents of
'/usr/local/bundle/gems/nokogiri-1.15.5/ext/nokogiri/tmp/mips64el-unknown-linux-abi64/ports/libxml2/2.11.6/configure.log'
-----
checking build system type... mips64el-unknown-linux-gnuabi64
checking host system type... Invalid configuration
`mips64el-unknown-linux-abi64': OS `abi64' not recognized
```