### PR TITLE
Remove leftover `passenger` references

### DIFF
--- a/5.0/alpine3.19/docker-entrypoint.sh
+++ b/5.0/alpine3.19/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"

--- a/5.0/alpine3.20/docker-entrypoint.sh
+++ b/5.0/alpine3.20/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"

--- a/5.0/bookworm/docker-entrypoint.sh
+++ b/5.0/bookworm/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"

--- a/5.1/alpine3.19/docker-entrypoint.sh
+++ b/5.1/alpine3.19/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"

--- a/5.1/alpine3.20/docker-entrypoint.sh
+++ b/5.1/alpine3.20/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"

--- a/5.1/bookworm/docker-entrypoint.sh
+++ b/5.1/bookworm/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 
 isLikelyRedmine=
 case "$1" in
-	rails | rake | passenger ) isLikelyRedmine=1 ;;
+	rails | rake ) isLikelyRedmine=1 ;;
 esac
 
 _fix_permissions() {
@@ -155,11 +155,6 @@ if [ -n "$isLikelyRedmine" ]; then
 
 	# remove PID file to enable restarting the container
 	rm -f tmp/pids/server.pid
-
-	if [ "$1" = 'passenger' ]; then
-		# Don't fear the reaper.
-		set -- tini -- "$@"
-	fi
 fi
 
 exec "$@"


### PR DESCRIPTION
Support for Passenger was removed in 5.0+, and all older versions are now gone/EOL so this code is reasonable to remove.

Technically, this was the only _official_ usage of `tini` in the image, so we could make an argument for removing that as well, but maybe it's worth keeping in since it _is_ likely useful for a lot of the strange things that Redmine might do for users who might need it?