### PR TITLE
Remove quoting from `adapter:` in `database.yml`

### DIFF
--- a/5.0/alpine3.20/docker-entrypoint.sh
+++ b/5.0/alpine3.20/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/5.0/alpine3.21/docker-entrypoint.sh
+++ b/5.0/alpine3.21/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/5.0/bookworm/docker-entrypoint.sh
+++ b/5.0/bookworm/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/5.1/alpine3.20/docker-entrypoint.sh
+++ b/5.1/alpine3.20/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/5.1/alpine3.21/docker-entrypoint.sh
+++ b/5.1/alpine3.21/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/5.1/bookworm/docker-entrypoint.sh
+++ b/5.1/bookworm/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/6.0/alpine3.20/docker-entrypoint.sh
+++ b/6.0/alpine3.20/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/6.0/alpine3.21/docker-entrypoint.sh
+++ b/6.0/alpine3.21/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/6.0/bookworm/docker-entrypoint.sh
+++ b/6.0/bookworm/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -127,7 +127,12 @@ if [ -n "$isLikelyRedmine" ]; then
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"
 			[ -n "$val" ] || continue
-			echo "  $var: \"$val\"" >> config/database.yml
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
 		done
 	fi
 


### PR DESCRIPTION
Fixes https://github.com/docker-library/redmine/issues/353

This still needs testing -- ideally we'd add some automated tests, maybe even for _all_ our supported database adapters, but that's not totally trivial.

(I have something locally for MySQL that I apparently was working on back in 2021, but it doesn't run successfully right now regardless of the issue this fixes, and I have no memory of writing it. :joy:)