### PR TITLE
Add missing dev that was unintentionally included in slim and alpine ruby images

### DIFF
--- a/5.0/alpine3.20/Dockerfile
+++ b/5.0/alpine3.20/Dockerfile
@@ -104,6 +104,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/5.0/alpine3.21/Dockerfile
+++ b/5.0/alpine3.21/Dockerfile
@@ -104,6 +104,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/5.0/bookworm/Dockerfile
+++ b/5.0/bookworm/Dockerfile
@@ -105,6 +105,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		patch \
 		pkgconf \

--- a/5.1/alpine3.20/Dockerfile
+++ b/5.1/alpine3.20/Dockerfile
@@ -104,6 +104,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/5.1/alpine3.21/Dockerfile
+++ b/5.1/alpine3.21/Dockerfile
@@ -104,6 +104,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -105,6 +105,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		patch \
 		pkgconf \

--- a/6.0/alpine3.20/Dockerfile
+++ b/6.0/alpine3.20/Dockerfile
@@ -103,6 +103,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/6.0/alpine3.21/Dockerfile
+++ b/6.0/alpine3.21/Dockerfile
@@ -103,6 +103,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/6.0/bookworm/Dockerfile
+++ b/6.0/bookworm/Dockerfile
@@ -105,6 +105,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		patch \
 		pkgconf \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -100,6 +100,7 @@ RUN set -eux; \
 		postgresql-dev \
 		sqlite-dev \
 		ttf2ufm \
+		yaml-dev \
 		zlib-dev \
 	; \
 	\

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -99,6 +99,7 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		patch \
 		pkgconf \


### PR DESCRIPTION
```console
+ gosu redmine bundle install --jobs 4
...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/psych-5.2.2/ext/psych
/usr/local/bin/ruby extconf.rb
checking for pkg-config for yaml-0.1... not found
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
```

Refs: https://github.com/docker-library/ruby/pull/493