### PR TITLE
Add support for REDMINE_DB_SCHEMA_SEARCH_PATH to configure custom PostgreSQL schema

### DIFF
--- a/5.0/alpine3.20/docker-entrypoint.sh
+++ b/5.0/alpine3.20/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/5.0/alpine3.21/docker-entrypoint.sh
+++ b/5.0/alpine3.21/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/5.0/bookworm/docker-entrypoint.sh
+++ b/5.0/bookworm/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/5.1/alpine3.20/docker-entrypoint.sh
+++ b/5.1/alpine3.20/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/5.1/alpine3.21/docker-entrypoint.sh
+++ b/5.1/alpine3.21/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/5.1/bookworm/docker-entrypoint.sh
+++ b/5.1/bookworm/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/6.0/alpine3.20/docker-entrypoint.sh
+++ b/6.0/alpine3.20/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/6.0/alpine3.21/docker-entrypoint.sh
+++ b/6.0/alpine3.21/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/6.0/bookworm/docker-entrypoint.sh
+++ b/6.0/bookworm/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -83,6 +83,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
 			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
 			file_env 'REDMINE_DB_ENCODING' 'utf8'
+			file_env 'REDMINE_DB_SCHEMA_SEARCH_PATH' 'public'
 		elif [ "$REDMINE_DB_SQLSERVER" ]; then
 			adapter='sqlserver'
 			host="$REDMINE_DB_SQLSERVER"
@@ -123,6 +124,7 @@ if [ -n "$isLikelyRedmine" ]; then
 			password \
 			database \
 			encoding \
+			schema_search_path \
 		; do
 			env="REDMINE_DB_${var^^}"
 			val="${!env}"


### PR DESCRIPTION
#### Summary
- Introduced `REDMINE_DB_SCHEMA_SEARCH_PATH` environment variable to allow configuring a custom PostgreSQL schema.
- Default behavior remains unchanged (`public` schema).

#### Usage
Set the `REDMINE_DB_SCHEMA_SEARCH_PATH` environment variable to the desired schema:

```yaml
environment:
  REDMINE_DB_SCHEMA_SEARCH_PATH: custom_schema
```