### PR TITLE
Drop creating secrets.yml and just use `SECRET_KEY_BASE` env

### DIFF
--- a/5.0/alpine3.20/Dockerfile
+++ b/5.0/alpine3.20/Dockerfile
@@ -82,6 +82,15 @@ RUN set -eux; \
 	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apk add --no-cache patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apk del --no-network patch; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/5.0/alpine3.21/Dockerfile
+++ b/5.0/alpine3.21/Dockerfile
@@ -82,6 +82,15 @@ RUN set -eux; \
 	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apk add --no-cache patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apk del --no-network patch; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/5.0/bookworm/Dockerfile
+++ b/5.0/bookworm/Dockerfile
@@ -86,6 +86,17 @@ RUN set -eux; \
 	curl -fL -o redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apt-get update; \
+	apt-get install -y --no-install-recommends patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apt-get purge -y --auto-remove patch; \
+	rm -rf /var/lib/apt/lists/*; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/5.1/alpine3.20/Dockerfile
+++ b/5.1/alpine3.20/Dockerfile
@@ -82,6 +82,15 @@ RUN set -eux; \
 	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apk add --no-cache patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apk del --no-network patch; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/5.1/alpine3.21/Dockerfile
+++ b/5.1/alpine3.21/Dockerfile
@@ -82,6 +82,15 @@ RUN set -eux; \
 	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apk add --no-cache patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apk del --no-network patch; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -86,6 +86,17 @@ RUN set -eux; \
 	curl -fL -o redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apt-get update; \
+	apt-get install -y --no-install-recommends patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apt-get purge -y --auto-remove patch; \
+	rm -rf /var/lib/apt/lists/*; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -53,7 +53,7 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/gosu; \
 	gosu --version; \
 	gosu nobody true
-{{ if [ "5.0", "5.1" ] | index(env.version) then ( -}}
+{{ if env.version | IN("5.0", "5.1") then ( -}}
 RUN set -eux; ln -svf gosu /usr/local/bin/su-exec; su-exec nobody true # backwards compatibility (removed in Redmine 5.2+)
 {{ ) else "" end -}}
 
@@ -78,6 +78,17 @@ RUN set -eux; \
 	wget -O redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+{{ if .version | IN("5.0.10", "5.1.5") then ( -}}
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apk add --no-cache patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apk del --no-network patch; \
+{{ ) else "" end -}}
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -80,6 +80,19 @@ RUN set -eux; \
 	curl -fL -o redmine.tar.gz "$REDMINE_DOWNLOAD_URL"; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
+{{ if .version | IN("5.0.10", "5.1.5") then ( -}}
+	# https://www.redmine.org/issues/42113 (aka https://github.com/rails/rails/issues/54260)
+	# 5.1: https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4
+	# 5.0: https://github.com/redmine/redmine/commit/f27570120b7a672249bfebfe4d62da506785e146
+	apt-get update; \
+	apt-get install -y --no-install-recommends patch; \
+	wget -O 42113.patch 'https://github.com/redmine/redmine/commit/c7b1f00fc1b42fd9f77b8e6574dae453ced642b4.patch?full_index=1'; \
+	echo 'e352699be3995ff6e3b0066a478e377922fa95ce9fe4729240cd98dcee3c8575 *42113.patch' | sha256sum -c -; \
+	patch -p1 < 42113.patch; \
+	rm 42113.patch; \
+	apt-get purge -y --auto-remove patch; \
+	rm -rf /var/lib/apt/lists/*; \
+{{ ) else "" end -}}
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \


### PR DESCRIPTION
Rails 7.1-7.2 deprecated/removed `config/secrets.yml` usage and instead use `credentials`, so our generated `secrets.yml` is no longer used (which is the cause of https://github.com/docker-library/redmine/issues/349).

Rails 7.2 is used in Redmine 6.0+. Rails 6.1 is used in Redmine 5.0 and 5.1. Rails 7.2 and 6.1 both support the `SECRET_KEY_BASE` environment variable, so let's use that instead. Users can continue to use the `REDMINE_SECRET_KEY_BASE` or `REDMINE_SECRET_KEY_BASE_FILE` variables or swap to `SECRET_KEY_BASE`.

Fixes https://github.com/docker-library/redmine/issues/349

---

See removals and deprecations:
https://guides.rubyonrails.org/7_1_release_notes.html
https://guides.rubyonrails.org/7_2_release_notes.html