### PR TITLE
Add missing assets directory

### DIFF
--- a/5.0/alpine3.20/Dockerfile
+++ b/5.0/alpine3.20/Dockerfile
@@ -78,7 +78,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/5.0/alpine3.20/docker-entrypoint.sh
+++ b/5.0/alpine3.20/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/5.0/alpine3.21/Dockerfile
+++ b/5.0/alpine3.21/Dockerfile
@@ -78,7 +78,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/5.0/alpine3.21/docker-entrypoint.sh
+++ b/5.0/alpine3.21/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/5.0/bookworm/Dockerfile
+++ b/5.0/bookworm/Dockerfile
@@ -81,7 +81,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/5.0/bookworm/docker-entrypoint.sh
+++ b/5.0/bookworm/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/5.1/alpine3.20/Dockerfile
+++ b/5.1/alpine3.20/Dockerfile
@@ -78,7 +78,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/5.1/alpine3.20/docker-entrypoint.sh
+++ b/5.1/alpine3.20/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/5.1/alpine3.21/Dockerfile
+++ b/5.1/alpine3.21/Dockerfile
@@ -78,7 +78,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/5.1/alpine3.21/docker-entrypoint.sh
+++ b/5.1/alpine3.21/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -81,7 +81,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/5.1/bookworm/docker-entrypoint.sh
+++ b/5.1/bookworm/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/6.0/alpine3.20/Dockerfile
+++ b/6.0/alpine3.20/Dockerfile
@@ -77,7 +77,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/6.0/alpine3.20/docker-entrypoint.sh
+++ b/6.0/alpine3.20/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/6.0/alpine3.21/Dockerfile
+++ b/6.0/alpine3.21/Dockerfile
@@ -77,7 +77,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/6.0/alpine3.21/docker-entrypoint.sh
+++ b/6.0/alpine3.21/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/6.0/bookworm/Dockerfile
+++ b/6.0/bookworm/Dockerfile
@@ -81,7 +81,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/6.0/bookworm/docker-entrypoint.sh
+++ b/6.0/bookworm/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -131,7 +131,8 @@ RUN set -eux; \
 	echo "$REDMINE_DOWNLOAD_SHA256 *redmine.tar.gz" | sha256sum -c -; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
-	mkdir -p log public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX config db sqlite; \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,14 +31,14 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/plugin_assets tmp ) args=()
+	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 
 		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
 		local filesOwnerMode
 		filesOwnerMode="$(stat -c '%U:%a' files)"
-		if [ "$files" != 'redmine:755' ]; then
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
 			dirs+=( files )
 		fi
 	fi


### PR DESCRIPTION
Create and fix permissions on the `public/assets` directory. I think this is only used in 6+, but it should be harmless/unused in `5.x`.

Also fix the "$filesOwnerMode" variable name ([`set -u`](https://github.com/docker-library/redmine/blob/7c0163067f16063562b8c7a8d2d2778561d1d7c3/docker-entrypoint.sh#L3) would've caught this 🙈😢).

This might be the solution to https://github.com/docker-library/redmine/issues/358