### PR TITLE
Also consider "bundle" to be likely redmine

### DIFF
--- a/5.1/alpine3.21/docker-entrypoint.sh
+++ b/5.1/alpine3.21/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {

--- a/5.1/alpine3.22/docker-entrypoint.sh
+++ b/5.1/alpine3.22/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {

--- a/5.1/bookworm/docker-entrypoint.sh
+++ b/5.1/bookworm/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {

--- a/6.0/alpine3.21/docker-entrypoint.sh
+++ b/6.0/alpine3.21/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {

--- a/6.0/alpine3.22/docker-entrypoint.sh
+++ b/6.0/alpine3.22/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {

--- a/6.0/bookworm/docker-entrypoint.sh
+++ b/6.0/bookworm/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,6 +27,7 @@ file_env() {
 isLikelyRedmine=
 case "$1" in
 	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
 esac
 
 _fix_permissions() {


### PR DESCRIPTION
This helps with having a separate sidekiq container without hacks (see what I have to use currently and the comment improvements:

``` yaml
  sidekiq:
    image: 'redmine:6.0.6'
    pull_policy: 'never'
    # command: 'bundle exec sidekiq' # After this PR is accepted
    command: sh -c '/docker-entrypoint.sh rake --version && gosu redmine bundle exec sidekiq'
    env_file:
      - './data/redmine/config/.env'
    volumes:
      - type: 'bind'
        source: './data/redmine/config/configuration.yml'
        target: '/usr/src/redmine/config/configuration.yml'
    depends_on:
      mysql:
        condition: 'service_healthy'
      redis:
        condition: 'service_healthy'
```

As you see atm I have to trigger `/docker-entrypoint.sh rake --version` so it sets the DB etc, this can be avoided if you consider "bundle" as a redmine command.