### PR TITLE
Fix 6.1 build on i386 (and hopefully other arches)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         name: Generate Jobs
         run: |
           strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
+          strategy="$("$BASHBREW_SCRIPTS/github-actions/munge-i386.sh" -c <<<"$strategy")"
           echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid
 


### PR DESCRIPTION
Redmine 6.1 is failing to build on every architecture except amd64 and arm64, which isn't terribly unexpected (given those are the only ones that are likely to have published precompiled dependencies and #390 removed the variable that had us building _all_ our dependencies on every architecture).

This adds i386 building to CI (in a commit by itself so we can see that the build currently fails), and a follow-up commit which makes i386 building succeed (with the implied hope that it fixes more architectures too).