### PR TITLE
Drop arm32v6 for 6.1+

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -108,6 +108,14 @@ for version; do
 				| join(" ")
 			')"
 		fi
+		if [[ "$variant" = 'alpine'* ]] && [ "$version" != '5.1' ] && [ "$version" != '6.0' ]; then
+			# 6.1 alpine fails to build in a reasonable time on arm32v6
+			variantArches="$(jq <<<"$variantArches" --raw-input --raw-output '
+				split(" ")
+				| map(select(IN("arm32v6") | not))
+				| join(" ")
+			')"
+		fi
 
 		variantAliases=( "${versionAliases[@]/%/-$variant}" )
 		variantAliases=( "${variantAliases[@]//latest-/}" )


### PR DESCRIPTION
This removes `arm32v6` (alpine) for 6.1 and above.

The builds are timing out on our build servers (after 3 hours) and the node is constantly at 100% CPU after the first 5-10 minutes. 😞 But I can locally build an `arm32v6` image via qemu user-mode in just 8 minutes. 😕 We don't have anything concurrently on the node, so it has a "dedicated" 8 vCPUs.

I'm not sure what to check to find a real solution.

Failing (timeout):
```console
Fetching doorkeeper-i18n 5.2.7
Installing doorkeeper-i18n 5.2.7
Cancelling nested steps due to timeout
Sending interrupt signal to process
#12 CANCELED
ERROR: failed to solve: Canceled: context canceled
script returned exit code 1
```

Local build:
```console
$ time docker build --platform linux/arm/v6 --progress=plain --build-arg BUILDKIT_DOCKERFILE_CHECK=skip=all 6.1/alpine3.22/
...
#12 308.3 Fetching doorkeeper-i18n 5.2.7
#12 308.4 Installing doorkeeper-i18n 5.2.7
#12 468.7 Bundle complete! 57 Gemfile dependencies, 100 gems now installed.
#12 468.7 Gems in the groups 'development' and 'test' were not installed.
#12 468.7 Use `bundle info [gemname]` to see where a bundled gem is installed.
...
```