### PR TITLE
Fix arbitrary user permissions

### DIFF
--- a/5.1/alpine3.21/Dockerfile
+++ b/5.1/alpine3.21/Dockerfile
@@ -79,11 +79,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/plugin_assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 # build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1

--- a/5.1/alpine3.21/docker-entrypoint.sh
+++ b/5.1/alpine3.21/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/5.1/alpine3.22/Dockerfile
+++ b/5.1/alpine3.22/Dockerfile
@@ -79,11 +79,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/plugin_assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 # build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1

--- a/5.1/alpine3.22/docker-entrypoint.sh
+++ b/5.1/alpine3.22/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/5.1/bookworm/Dockerfile
+++ b/5.1/bookworm/Dockerfile
@@ -82,11 +82,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/plugin_assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/5.1/bookworm/docker-entrypoint.sh
+++ b/5.1/bookworm/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/5.1/trixie/Dockerfile
+++ b/5.1/trixie/Dockerfile
@@ -80,11 +80,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/plugin_assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/5.1/trixie/docker-entrypoint.sh
+++ b/5.1/trixie/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.0/alpine3.21/Dockerfile
+++ b/6.0/alpine3.21/Dockerfile
@@ -78,11 +78,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 # build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1

--- a/6.0/alpine3.21/docker-entrypoint.sh
+++ b/6.0/alpine3.21/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.0/alpine3.22/Dockerfile
+++ b/6.0/alpine3.22/Dockerfile
@@ -78,11 +78,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 # build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)
 ENV BUNDLE_FORCE_RUBY_PLATFORM 1

--- a/6.0/alpine3.22/docker-entrypoint.sh
+++ b/6.0/alpine3.22/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.0/bookworm/Dockerfile
+++ b/6.0/bookworm/Dockerfile
@@ -82,11 +82,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/6.0/bookworm/docker-entrypoint.sh
+++ b/6.0/bookworm/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.0/trixie/Dockerfile
+++ b/6.0/trixie/Dockerfile
@@ -80,11 +80,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/6.0/trixie/docker-entrypoint.sh
+++ b/6.0/trixie/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.1/alpine3.21/Dockerfile
+++ b/6.1/alpine3.21/Dockerfile
@@ -78,11 +78,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \

--- a/6.1/alpine3.21/docker-entrypoint.sh
+++ b/6.1/alpine3.21/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.1/alpine3.22/Dockerfile
+++ b/6.1/alpine3.22/Dockerfile
@@ -78,11 +78,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \

--- a/6.1/alpine3.22/docker-entrypoint.sh
+++ b/6.1/alpine3.22/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.1/bookworm/Dockerfile
+++ b/6.1/bookworm/Dockerfile
@@ -82,11 +82,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/6.1/bookworm/docker-entrypoint.sh
+++ b/6.1/bookworm/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/6.1/trixie/Dockerfile
+++ b/6.1/trixie/Dockerfile
@@ -80,11 +80,12 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- 'config' 'db' 'log' 'public/assets' 'sqlite' 'tmp' 'tmp/pdf' 'tmp/pids'; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/6.1/trixie/docker-entrypoint.sh
+++ b/6.1/trixie/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -134,11 +134,33 @@ RUN set -eux; \
 	tar -xf redmine.tar.gz --strip-components=1; \
 	rm redmine.tar.gz files/delete.me log/delete.me; \
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	mkdir -p log public/assets public/plugin_assets sqlite tmp/pdf tmp/pids; \
+	set -- {{
+		[
+			"config",   # database.yml created by the entrypoint and secret_token.rb if not using SECRET_KEY_BASE
+			"db",       # schema.rb is created/edited during 'rake db:migrate'
+			"sqlite",   # database dir when using sqlite
+			"tmp/pids", # pid file location
+
+			# from RedmineInstall instructions
+			"log",
+			"tmp",
+			"tmp/pdf",
+			if (env.version | IN("5.1")) then
+				"public/plugin_assets"
+			else
+				"public/assets"
+			end,
+			empty
+			| @sh
+		]
+		| sort
+		| join(" ")
+	}}; \
+	mkdir -p "$@"; \
 	chown -R redmine:redmine ./; \
 # fix permissions for running as an arbitrary user
-	chmod -R ugo=rwX config db sqlite; \
-	find log tmp -type d -exec chmod 1777 '{}' +
+	chmod -R ugo=rwX "$@"; \
+	find "$@" -type d -exec chmod 1777 '{}' +
 
 {{ if is_alpine and IN(env.version; "5.1", "6.0") then ( -}}
 # build for musl-libc, not glibc (see https://github.com/sparklemotion/nokogiri/issues/2075, https://github.com/rubygems/rubygems/issues/3174)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ esac
 
 _fix_permissions() {
 	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
-	local dirs=( config log public/assets public/plugin_assets tmp ) args=()
+	local dirs=( config log public/*assets tmp ) args=()
 	if [ "$(id -u)" = '0' ]; then
 		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
 


### PR DESCRIPTION
Added note about why each directory is included.

Fixes #400

```console
$ docker build 6.1/trixie/ -t redmine:6.1-test
...
$ docker run -it --rm --user 1234:5678 redmine:6.1-test
...
* Listening on http://0.0.0.0:3000
Use Ctrl-C to stop
```