### PR TITLE
Fix missing timezones in Trixie images

### DIFF
--- a/6.0/alpine3.22/Dockerfile
+++ b/6.0/alpine3.22/Dockerfile
@@ -134,7 +134,9 @@ RUN set -eux; \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps
+	apk del --no-network .build-deps; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.0/alpine3.23/Dockerfile
+++ b/6.0/alpine3.23/Dockerfile
@@ -134,7 +134,9 @@ RUN set -eux; \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps
+	apk del --no-network .build-deps; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.0/bookworm/Dockerfile
+++ b/6.0/bookworm/Dockerfile
@@ -140,7 +140,9 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.0/trixie/Dockerfile
+++ b/6.0/trixie/Dockerfile
@@ -23,6 +23,7 @@ RUN set -eux; \
 		openssh-client \
 		subversion \
 		tini \
+		tzdata-legacy \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -138,7 +139,9 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/alpine3.22/Dockerfile
+++ b/6.1/alpine3.22/Dockerfile
@@ -132,7 +132,9 @@ RUN set -eux; \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps
+	apk del --no-network .build-deps; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/alpine3.23/Dockerfile
+++ b/6.1/alpine3.23/Dockerfile
@@ -132,7 +132,9 @@ RUN set -eux; \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps
+	apk del --no-network .build-deps; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/bookworm/Dockerfile
+++ b/6.1/bookworm/Dockerfile
@@ -142,7 +142,9 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/trixie/Dockerfile
+++ b/6.1/trixie/Dockerfile
@@ -23,6 +23,7 @@ RUN set -eux; \
 		openssh-client \
 		subversion \
 		tini \
+		tzdata-legacy \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -140,7 +141,9 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -41,6 +41,11 @@ RUN groupadd -r -g 999 redmine && useradd -r -g redmine -u 999 redmine
 			# debian packages
 			"bzr",
 			"gsfonts", # for generating PNGs of Gantt charts
+			# redmine needs a rails update that includes https://github.com/rails/rails/pull/57266
+			# before it will handle the renamed timezones (they just fail to show in the redmine selector)
+			if env.variant == "trixie" and IN(env.version; "6.0", "6.1") then
+				"tzdata-legacy"
+			else empty end,
 			empty
 		end
 	] | sort | (
@@ -263,7 +268,7 @@ RUN set -eux; \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps
+	apk del --no-network .build-deps; \
 {{ ) else ( -}}
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
@@ -277,8 +282,10 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 {{ ) end -}}
+	# verify Kyiv timezone isn't missing
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 


### PR DESCRIPTION
By adding `tzdata-legacy` until rails includes the fix (https://github.com/rails/rails/pull/57266) and Redmine includes the updated rails.

Fixes https://github.com/docker-library/redmine/issues/417