### PR TITLE
Fix failing arm32v5 builds

### DIFF
--- a/6.0/bookworm/Dockerfile
+++ b/6.0/bookworm/Dockerfile
@@ -120,8 +120,14 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
+# force them to compile so that they don't pull arm32v[6-7] libraries
+	arch="$(dpkg --print-architecture)"; \
+	if [ "$arch" = 'armel' ]; then \
+		gosu redmine bundle config set force_ruby_platform true; \
+	fi; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config build.nokogiri --use-system-libraries; \
+	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user

--- a/6.0/trixie/Dockerfile
+++ b/6.0/trixie/Dockerfile
@@ -119,8 +119,14 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
+# force them to compile so that they don't pull arm32v[6-7] libraries
+	arch="$(dpkg --print-architecture)"; \
+	if [ "$arch" = 'armel' ]; then \
+		gosu redmine bundle config set force_ruby_platform true; \
+	fi; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config build.nokogiri --use-system-libraries; \
+	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user

--- a/6.1/bookworm/Dockerfile
+++ b/6.1/bookworm/Dockerfile
@@ -122,8 +122,14 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
+# force them to compile so that they don't pull arm32v[6-7] libraries
+	arch="$(dpkg --print-architecture)"; \
+	if [ "$arch" = 'armel' ]; then \
+		gosu redmine bundle config set force_ruby_platform true; \
+	fi; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config build.nokogiri --use-system-libraries; \
+	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user

--- a/6.1/trixie/Dockerfile
+++ b/6.1/trixie/Dockerfile
@@ -121,8 +121,14 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
+# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
+# force them to compile so that they don't pull arm32v[6-7] libraries
+	arch="$(dpkg --print-architecture)"; \
+	if [ "$arch" = 'armel' ]; then \
+		gosu redmine bundle config set force_ruby_platform true; \
+	fi; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config build.nokogiri --use-system-libraries; \
+	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -242,8 +242,14 @@ RUN set -eux; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
 {{ if is_alpine then "" else ( -}}
+# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
+# force them to compile so that they don't pull arm32v[6-7] libraries
+	arch="$(dpkg --print-architecture)"; \
+	if [ "$arch" = 'armel' ]; then \
+		gosu redmine bundle config set force_ruby_platform true; \
+	fi; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config build.nokogiri --use-system-libraries; \
+	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 {{ ) end -}}
 	gosu redmine bundle install --jobs "$(nproc)"; \
 	rm ./config/database.yml; \


### PR DESCRIPTION
compile gems instead of relying on "arm-linux-gnu" pre-compiled gems

The `arm32v5` image has been broken since `5.0.6`; the last working image is `5.0.5`. 😞 The breakage was only noticed with the addition of `bundle exec rake time:zones:all` during the build in https://github.com/docker-library/redmine/pull/418.

---

It broke because Redmine `5.0.6` included a [`nokogiri` bump](https://github.com/redmine/redmine/commit/e07214cb6025ff9639dff94ffd5c8d5105ee8e5c#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR21) to `1.15.2`. The nokogiri gem started providing pre-compiled libraries in their gem under "arm-linux" in `1.14.x` (which has since evolved to "arm-linux-gnu" so that they can provide "-musl" builds as well). And `rubygems` architecture matching is not specific enough for [arm variants](https://github.com/ruby/rubygems/blob/cae04de04e85f53abd1c38c8d885e730113af8d1/lib/rubygems/platform.rb#L188-L189); a gem that is provided as "arm-linux" is treated as "generic 32-bit ARM" when the gem creators are compiling them in `armv7` or `armv6` environments.