### PR TITLE
Add Redmine 7.0 support (Ruby 4.0, Rails 8.1) + trixie/alpine templat…

### DIFF
--- a/6.0/alpine3.23/Dockerfile
+++ b/6.0/alpine3.23/Dockerfile
@@ -116,6 +116,10 @@ RUN set -eux; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -130,13 +134,12 @@ RUN set -eux; \
 		| sort -u \
 		| awk ' \
 			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
 			{ print "so:" $1 } \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apk del --no-network .build-deps
 
 VOLUME /usr/src/redmine/files
 

--- a/6.0/alpine3.24/Dockerfile
+++ b/6.0/alpine3.24/Dockerfile
@@ -116,6 +116,10 @@ RUN set -eux; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -130,13 +134,12 @@ RUN set -eux; \
 		| sort -u \
 		| awk ' \
 			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
 			{ print "so:" $1 } \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apk del --no-network .build-deps
 
 VOLUME /usr/src/redmine/files
 

--- a/6.0/trixie/Dockerfile
+++ b/6.0/trixie/Dockerfile
@@ -128,6 +128,10 @@ RUN set -eux; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
 	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -145,9 +149,7 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/alpine3.23/Dockerfile
+++ b/6.1/alpine3.23/Dockerfile
@@ -113,6 +113,10 @@ RUN set -eux; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -128,13 +132,12 @@ RUN set -eux; \
 		| awk ' \
 			$1 == "libc.so" { next } \
 			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
 			{ print "so:" $1 } \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apk del --no-network .build-deps
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/alpine3.24/Dockerfile
+++ b/6.1/alpine3.24/Dockerfile
@@ -113,6 +113,10 @@ RUN set -eux; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -128,13 +132,12 @@ RUN set -eux; \
 		| awk ' \
 			$1 == "libc.so" { next } \
 			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
 			{ print "so:" $1 } \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apk del --no-network .build-deps
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/bookworm/Dockerfile
+++ b/6.1/bookworm/Dockerfile
@@ -131,6 +131,10 @@ RUN set -eux; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
 	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -148,9 +152,7 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 VOLUME /usr/src/redmine/files
 

--- a/6.1/trixie/Dockerfile
+++ b/6.1/trixie/Dockerfile
@@ -130,6 +130,10 @@ RUN set -eux; \
 # nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
 	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -147,9 +151,7 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 VOLUME /usr/src/redmine/files
 

--- a/7.0/alpine3.23/Dockerfile
+++ b/7.0/alpine3.23/Dockerfile
@@ -4,42 +4,40 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM ruby:3.3-slim-bookworm
+FROM ruby:4.0.6-alpine3.23
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
-RUN groupadd -r -g 999 redmine && useradd -r -g redmine -u 999 redmine
+# alpine already has a gid 999, so we'll use the next id
+RUN addgroup -S -g 1000 redmine && adduser -S -H -G redmine -u 999 redmine
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		bzr \
+	apk add --no-cache \
+		bash \
+		breezy \
 		ca-certificates \
+		findutils \
 		ghostscript \
+		ghostscript-fonts \
 		git \
-		gsfonts \
 		imagemagick \
 		mercurial \
 		openssh-client \
 		subversion \
 		tini \
+		tzdata \
 		wget \
-	; \
-# allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
-	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
-	rm -rf /var/lib/apt/lists/*
+	;
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VERSION 1.19
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apk add --no-cache --virtual .gosu-deps \
+		dpkg \
 		gnupg \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
@@ -50,9 +48,7 @@ RUN set -eux; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apk del --no-network .gosu-deps; \
 	\
 # smoke test
 	chmod +x /usr/local/bin/gosu; \
@@ -71,9 +67,9 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 6.0.10
-ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-6.0.10.tar.gz
-ENV REDMINE_DOWNLOAD_SHA256 0f3f3a7159188fbd65a365519037ebe6882c6dace78d8630de22c570ff20ca77
+ENV REDMINE_VERSION 7.0.0
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-7.0.0.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 857e9f8860c31e4c531389e5d93eea26488dba69830484a3b0aa904be615e90a
 ENV RAILS_LOG_TO_STDOUT true
 
 RUN set -eux; \
@@ -90,23 +86,19 @@ RUN set -eux; \
 	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		default-libmysqlclient-dev \
+	apk add --no-cache --virtual .build-deps \
+		cargo \
+		clang21-dev \
+		coreutils \
 		freetds-dev \
 		gcc \
-		libpq-dev \
-		libsqlite3-dev \
-		libxml2-dev \
-		libxslt-dev \
-		libyaml-dev \
 		make \
+		mariadb-dev \
+		musl-dev \
 		patch \
-		pkgconf \
-		xz-utils \
+		postgresql-dev \
+		yaml-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	gosu redmine bundle config --local without 'development test'; \
 # https://github.com/redmine/redmine/commit/23dc108e70a0794f444803ac827a690085dcd557
@@ -120,14 +112,6 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
-# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
-# force them to compile so that they don't pull arm32v[6-7] libraries
-	arch="$(dpkg --print-architecture)"; \
-	if [ "$arch" = 'armel' ]; then \
-		gosu redmine bundle config set force_ruby_platform true; \
-	fi; \
-# nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 # verify Kyiv timezone isn't missing; must run BEFORE removing the stub
 # database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
@@ -138,19 +122,22 @@ RUN set -eux; \
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
 	rm -rf ~redmine/.bundle; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+# https://github.com/naitoh/rbpdf/issues/31
+	rm /usr/local/bundle/gems/rbpdf-font-1.19.*/lib/fonts/ttf2ufm/ttf2ufm; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/bundle/gems \
+		| tr ',' '\n' \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-# https://manpages.debian.org/trixie/dpkg/dpkg-query.1.en.html#S (we ignore diversions and it'll be really unusual for more than one package to provide any given .so file)
-		| awk 'sub(":$", "", $1) { print $1 }' \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+		| awk ' \
+			$1 == "libc.so" { next } \
+			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
+			{ print "so:" $1 } \
+		' \
+	)"; \
+	apk add --no-network --virtual .redmine-rundeps $runDeps; \
+	apk del --no-network .build-deps
 
 VOLUME /usr/src/redmine/files
 

--- a/7.0/alpine3.23/docker-entrypoint.sh
+++ b/7.0/alpine3.23/docker-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+# TODO add "-u"
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+isLikelyRedmine=
+case "$1" in
+	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
+esac
+
+_fix_permissions() {
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	local dirs=( config log public/*assets tmp ) args=()
+	if [ "$(id -u)" = '0' ]; then
+		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
+
+		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
+		local filesOwnerMode
+		filesOwnerMode="$(stat -c '%U:%a' files)"
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
+			dirs+=( files )
+		fi
+	fi
+	# directories 755, files 644:
+	args+=( ${args[@]:+,} '(' -type d '!' -perm 755 -exec sh -c 'chmod 755 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	args+=( ${args[@]:+,} '(' -type f '!' -perm 644 -exec sh -c 'chmod 644 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	find "${dirs[@]}" "${args[@]}"
+}
+
+# allow the container to be started with `--user`
+if [ -n "$isLikelyRedmine" ] && [ "$(id -u)" = '0' ]; then
+	_fix_permissions
+	exec gosu redmine "$BASH_SOURCE" "$@"
+fi
+
+if [ -n "$isLikelyRedmine" ]; then
+	_fix_permissions
+	if [ ! -f './config/database.yml' ]; then
+		file_env 'REDMINE_DB_MYSQL'
+		file_env 'REDMINE_DB_POSTGRES'
+		file_env 'REDMINE_DB_SQLSERVER'
+
+		if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
+			export REDMINE_DB_MYSQL='mysql'
+		elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
+			export REDMINE_DB_POSTGRES='postgres'
+		fi
+
+		if [ "$REDMINE_DB_MYSQL" ]; then
+			adapter='mysql2'
+			host="$REDMINE_DB_MYSQL"
+			file_env 'REDMINE_DB_PORT' '3306'
+			file_env 'REDMINE_DB_USERNAME' "${MYSQL_ENV_MYSQL_USER:-root}"
+			file_env 'REDMINE_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+			file_env 'REDMINE_DB_DATABASE' "${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+			file_env 'REDMINE_DB_ENCODING' ''
+		elif [ "$REDMINE_DB_POSTGRES" ]; then
+			adapter='postgresql'
+			host="$REDMINE_DB_POSTGRES"
+			file_env 'REDMINE_DB_PORT' '5432'
+			file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
+			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+		elif [ "$REDMINE_DB_SQLSERVER" ]; then
+			adapter='sqlserver'
+			host="$REDMINE_DB_SQLSERVER"
+			file_env 'REDMINE_DB_PORT' '1433'
+			file_env 'REDMINE_DB_USERNAME' ''
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' ''
+			file_env 'REDMINE_DB_ENCODING' ''
+		else
+			echo >&2
+			echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
+			echo >&2
+			echo >&2 '*** Using sqlite3 as fallback. ***'
+			echo >&2
+
+			adapter='sqlite3'
+			host='localhost'
+			file_env 'REDMINE_DB_PORT' ''
+			file_env 'REDMINE_DB_USERNAME' 'redmine'
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' 'sqlite/redmine.db'
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+
+			mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
+			if [ "$(id -u)" = '0' ]; then
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
+			fi
+		fi
+
+		REDMINE_DB_ADAPTER="$adapter"
+		REDMINE_DB_HOST="$host"
+		echo "$RAILS_ENV:" > config/database.yml
+		for var in \
+			adapter \
+			host \
+			port \
+			username \
+			password \
+			database \
+			encoding \
+		; do
+			env="REDMINE_DB_${var^^}"
+			val="${!env}"
+			[ -n "$val" ] || continue
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
+		done
+	fi
+
+	# install additional gems for Gemfile.local and plugins
+	bundle check || bundle install
+
+	file_env 'REDMINE_SECRET_KEY_BASE'
+	# just use the rails variable rather than trying to put it into a yml file
+	# https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/application.rb#L438
+	# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L484 (rails 7.1-stable)
+	if [ -n "${SECRET_KEY_BASE:-}" ] && [ -n "${REDMINE_SECRET_KEY_BASE:-}" ]; then
+		echo >&2
+		echo >&2 'warning: both SECRET_KEY_BASE and REDMINE_SECRET_KEY_BASE{_FILE} set, only SECRET_KEY_BASE will apply'
+		echo >&2
+	fi
+	: "${SECRET_KEY_BASE:=${REDMINE_SECRET_KEY_BASE:-}}"
+	export SECRET_KEY_BASE
+	if [ -z "$SECRET_KEY_BASE" ]; then
+		# https://github.com/docker-library/redmine/issues/397
+		# empty string is truthy in ruby and so masks the generated fallback config
+		# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L454
+		unset SECRET_KEY_BASE
+		# generate SECRET_KEY_BASE in-file since it is not set or empty; this is not recommended unless the secret_token.rb is saved when container is recreated
+		if [ ! -f config/initializers/secret_token.rb ]; then
+			echo >&2
+			echo >&2 'warning: no *SECRET_KEY_BASE set; running `rake generate_secret_token` to create one in "config/initializers/secret_token.rb"'
+			echo >&2
+			rake generate_secret_token
+		fi
+	fi
+
+	if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+		rake db:migrate
+	fi
+
+	if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
+		rake redmine:plugins:migrate
+	fi
+
+	# remove PID file to enable restarting the container
+	rm -f tmp/pids/server.pid
+fi
+
+exec "$@"

--- a/7.0/alpine3.24/Dockerfile
+++ b/7.0/alpine3.24/Dockerfile
@@ -4,42 +4,40 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM ruby:3.3-slim-bookworm
+FROM ruby:4.0.6-alpine3.24
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
-RUN groupadd -r -g 999 redmine && useradd -r -g redmine -u 999 redmine
+# alpine already has a gid 999, so we'll use the next id
+RUN addgroup -S -g 1000 redmine && adduser -S -H -G redmine -u 999 redmine
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		bzr \
+	apk add --no-cache \
+		bash \
+		breezy \
 		ca-certificates \
+		findutils \
 		ghostscript \
+		ghostscript-fonts \
 		git \
-		gsfonts \
 		imagemagick \
 		mercurial \
 		openssh-client \
 		subversion \
 		tini \
+		tzdata \
 		wget \
-	; \
-# allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
-	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
-	rm -rf /var/lib/apt/lists/*
+	;
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VERSION 1.19
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apk add --no-cache --virtual .gosu-deps \
+		dpkg \
 		gnupg \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
 	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
@@ -50,9 +48,7 @@ RUN set -eux; \
 	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apk del --no-network .gosu-deps; \
 	\
 # smoke test
 	chmod +x /usr/local/bin/gosu; \
@@ -71,9 +67,9 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 6.0.10
-ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-6.0.10.tar.gz
-ENV REDMINE_DOWNLOAD_SHA256 0f3f3a7159188fbd65a365519037ebe6882c6dace78d8630de22c570ff20ca77
+ENV REDMINE_VERSION 7.0.0
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-7.0.0.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 857e9f8860c31e4c531389e5d93eea26488dba69830484a3b0aa904be615e90a
 ENV RAILS_LOG_TO_STDOUT true
 
 RUN set -eux; \
@@ -90,23 +86,19 @@ RUN set -eux; \
 	find "$@" -type d -exec chmod 1777 '{}' +
 
 RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		default-libmysqlclient-dev \
+	apk add --no-cache --virtual .build-deps \
+		cargo \
+		clang21-dev \
+		coreutils \
 		freetds-dev \
 		gcc \
-		libpq-dev \
-		libsqlite3-dev \
-		libxml2-dev \
-		libxslt-dev \
-		libyaml-dev \
 		make \
+		mariadb-dev \
+		musl-dev \
 		patch \
-		pkgconf \
-		xz-utils \
+		postgresql-dev \
+		yaml-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	gosu redmine bundle config --local without 'development test'; \
 # https://github.com/redmine/redmine/commit/23dc108e70a0794f444803ac827a690085dcd557
@@ -120,14 +112,6 @@ RUN set -eux; \
 		echo "$adapter:" >> ./config/database.yml; \
 		echo "  adapter: $adapter" >> ./config/database.yml; \
 	done; \
-# ruby gems (like nokogiri) don't publish arm32v5-compatible, pre-compiled libraries
-# force them to compile so that they don't pull arm32v[6-7] libraries
-	arch="$(dpkg --print-architecture)"; \
-	if [ "$arch" = 'armel' ]; then \
-		gosu redmine bundle config set force_ruby_platform true; \
-	fi; \
-# nokogiri's vendored libxml2 + libxslt do not build on mips64le, so use the apt packages when building
-	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 	gosu redmine bundle install --jobs "$(nproc)"; \
 # verify Kyiv timezone isn't missing; must run BEFORE removing the stub
 # database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
@@ -138,19 +122,22 @@ RUN set -eux; \
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
 	rm -rf ~redmine/.bundle; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+# https://github.com/naitoh/rbpdf/issues/31
+	rm /usr/local/bundle/gems/rbpdf-font-1.19.*/lib/fonts/ttf2ufm/ttf2ufm; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/bundle/gems \
+		| tr ',' '\n' \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-# https://manpages.debian.org/trixie/dpkg/dpkg-query.1.en.html#S (we ignore diversions and it'll be really unusual for more than one package to provide any given .so file)
-		| awk 'sub(":$", "", $1) { print $1 }' \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+		| awk ' \
+			$1 == "libc.so" { next } \
+			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
+			{ print "so:" $1 } \
+		' \
+	)"; \
+	apk add --no-network --virtual .redmine-rundeps $runDeps; \
+	apk del --no-network .build-deps
 
 VOLUME /usr/src/redmine/files
 

--- a/7.0/alpine3.24/docker-entrypoint.sh
+++ b/7.0/alpine3.24/docker-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+# TODO add "-u"
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+isLikelyRedmine=
+case "$1" in
+	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
+esac
+
+_fix_permissions() {
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	local dirs=( config log public/*assets tmp ) args=()
+	if [ "$(id -u)" = '0' ]; then
+		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
+
+		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
+		local filesOwnerMode
+		filesOwnerMode="$(stat -c '%U:%a' files)"
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
+			dirs+=( files )
+		fi
+	fi
+	# directories 755, files 644:
+	args+=( ${args[@]:+,} '(' -type d '!' -perm 755 -exec sh -c 'chmod 755 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	args+=( ${args[@]:+,} '(' -type f '!' -perm 644 -exec sh -c 'chmod 644 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	find "${dirs[@]}" "${args[@]}"
+}
+
+# allow the container to be started with `--user`
+if [ -n "$isLikelyRedmine" ] && [ "$(id -u)" = '0' ]; then
+	_fix_permissions
+	exec gosu redmine "$BASH_SOURCE" "$@"
+fi
+
+if [ -n "$isLikelyRedmine" ]; then
+	_fix_permissions
+	if [ ! -f './config/database.yml' ]; then
+		file_env 'REDMINE_DB_MYSQL'
+		file_env 'REDMINE_DB_POSTGRES'
+		file_env 'REDMINE_DB_SQLSERVER'
+
+		if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
+			export REDMINE_DB_MYSQL='mysql'
+		elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
+			export REDMINE_DB_POSTGRES='postgres'
+		fi
+
+		if [ "$REDMINE_DB_MYSQL" ]; then
+			adapter='mysql2'
+			host="$REDMINE_DB_MYSQL"
+			file_env 'REDMINE_DB_PORT' '3306'
+			file_env 'REDMINE_DB_USERNAME' "${MYSQL_ENV_MYSQL_USER:-root}"
+			file_env 'REDMINE_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+			file_env 'REDMINE_DB_DATABASE' "${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+			file_env 'REDMINE_DB_ENCODING' ''
+		elif [ "$REDMINE_DB_POSTGRES" ]; then
+			adapter='postgresql'
+			host="$REDMINE_DB_POSTGRES"
+			file_env 'REDMINE_DB_PORT' '5432'
+			file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
+			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+		elif [ "$REDMINE_DB_SQLSERVER" ]; then
+			adapter='sqlserver'
+			host="$REDMINE_DB_SQLSERVER"
+			file_env 'REDMINE_DB_PORT' '1433'
+			file_env 'REDMINE_DB_USERNAME' ''
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' ''
+			file_env 'REDMINE_DB_ENCODING' ''
+		else
+			echo >&2
+			echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
+			echo >&2
+			echo >&2 '*** Using sqlite3 as fallback. ***'
+			echo >&2
+
+			adapter='sqlite3'
+			host='localhost'
+			file_env 'REDMINE_DB_PORT' ''
+			file_env 'REDMINE_DB_USERNAME' 'redmine'
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' 'sqlite/redmine.db'
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+
+			mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
+			if [ "$(id -u)" = '0' ]; then
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
+			fi
+		fi
+
+		REDMINE_DB_ADAPTER="$adapter"
+		REDMINE_DB_HOST="$host"
+		echo "$RAILS_ENV:" > config/database.yml
+		for var in \
+			adapter \
+			host \
+			port \
+			username \
+			password \
+			database \
+			encoding \
+		; do
+			env="REDMINE_DB_${var^^}"
+			val="${!env}"
+			[ -n "$val" ] || continue
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
+		done
+	fi
+
+	# install additional gems for Gemfile.local and plugins
+	bundle check || bundle install
+
+	file_env 'REDMINE_SECRET_KEY_BASE'
+	# just use the rails variable rather than trying to put it into a yml file
+	# https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/application.rb#L438
+	# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L484 (rails 7.1-stable)
+	if [ -n "${SECRET_KEY_BASE:-}" ] && [ -n "${REDMINE_SECRET_KEY_BASE:-}" ]; then
+		echo >&2
+		echo >&2 'warning: both SECRET_KEY_BASE and REDMINE_SECRET_KEY_BASE{_FILE} set, only SECRET_KEY_BASE will apply'
+		echo >&2
+	fi
+	: "${SECRET_KEY_BASE:=${REDMINE_SECRET_KEY_BASE:-}}"
+	export SECRET_KEY_BASE
+	if [ -z "$SECRET_KEY_BASE" ]; then
+		# https://github.com/docker-library/redmine/issues/397
+		# empty string is truthy in ruby and so masks the generated fallback config
+		# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L454
+		unset SECRET_KEY_BASE
+		# generate SECRET_KEY_BASE in-file since it is not set or empty; this is not recommended unless the secret_token.rb is saved when container is recreated
+		if [ ! -f config/initializers/secret_token.rb ]; then
+			echo >&2
+			echo >&2 'warning: no *SECRET_KEY_BASE set; running `rake generate_secret_token` to create one in "config/initializers/secret_token.rb"'
+			echo >&2
+			rake generate_secret_token
+		fi
+	fi
+
+	if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+		rake db:migrate
+	fi
+
+	if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
+		rake redmine:plugins:migrate
+	fi
+
+	# remove PID file to enable restarting the container
+	rm -f tmp/pids/server.pid
+fi
+
+exec "$@"

--- a/7.0/bookworm/Dockerfile
+++ b/7.0/bookworm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM ruby:3.3-slim-bookworm
+FROM ruby:4.0.6-slim-bookworm
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
@@ -71,9 +71,9 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 6.0.10
-ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-6.0.10.tar.gz
-ENV REDMINE_DOWNLOAD_SHA256 0f3f3a7159188fbd65a365519037ebe6882c6dace78d8630de22c570ff20ca77
+ENV REDMINE_VERSION 7.0.0
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-7.0.0.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 857e9f8860c31e4c531389e5d93eea26488dba69830484a3b0aa904be615e90a
 ENV RAILS_LOG_TO_STDOUT true
 
 RUN set -eux; \
@@ -93,9 +93,11 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		cargo \
 		default-libmysqlclient-dev \
 		freetds-dev \
 		gcc \
+		libclang-dev \
 		libpq-dev \
 		libsqlite3-dev \
 		libxml2-dev \

--- a/7.0/bookworm/docker-entrypoint.sh
+++ b/7.0/bookworm/docker-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+# TODO add "-u"
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+isLikelyRedmine=
+case "$1" in
+	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
+esac
+
+_fix_permissions() {
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	local dirs=( config log public/*assets tmp ) args=()
+	if [ "$(id -u)" = '0' ]; then
+		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
+
+		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
+		local filesOwnerMode
+		filesOwnerMode="$(stat -c '%U:%a' files)"
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
+			dirs+=( files )
+		fi
+	fi
+	# directories 755, files 644:
+	args+=( ${args[@]:+,} '(' -type d '!' -perm 755 -exec sh -c 'chmod 755 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	args+=( ${args[@]:+,} '(' -type f '!' -perm 644 -exec sh -c 'chmod 644 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	find "${dirs[@]}" "${args[@]}"
+}
+
+# allow the container to be started with `--user`
+if [ -n "$isLikelyRedmine" ] && [ "$(id -u)" = '0' ]; then
+	_fix_permissions
+	exec gosu redmine "$BASH_SOURCE" "$@"
+fi
+
+if [ -n "$isLikelyRedmine" ]; then
+	_fix_permissions
+	if [ ! -f './config/database.yml' ]; then
+		file_env 'REDMINE_DB_MYSQL'
+		file_env 'REDMINE_DB_POSTGRES'
+		file_env 'REDMINE_DB_SQLSERVER'
+
+		if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
+			export REDMINE_DB_MYSQL='mysql'
+		elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
+			export REDMINE_DB_POSTGRES='postgres'
+		fi
+
+		if [ "$REDMINE_DB_MYSQL" ]; then
+			adapter='mysql2'
+			host="$REDMINE_DB_MYSQL"
+			file_env 'REDMINE_DB_PORT' '3306'
+			file_env 'REDMINE_DB_USERNAME' "${MYSQL_ENV_MYSQL_USER:-root}"
+			file_env 'REDMINE_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+			file_env 'REDMINE_DB_DATABASE' "${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+			file_env 'REDMINE_DB_ENCODING' ''
+		elif [ "$REDMINE_DB_POSTGRES" ]; then
+			adapter='postgresql'
+			host="$REDMINE_DB_POSTGRES"
+			file_env 'REDMINE_DB_PORT' '5432'
+			file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
+			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+		elif [ "$REDMINE_DB_SQLSERVER" ]; then
+			adapter='sqlserver'
+			host="$REDMINE_DB_SQLSERVER"
+			file_env 'REDMINE_DB_PORT' '1433'
+			file_env 'REDMINE_DB_USERNAME' ''
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' ''
+			file_env 'REDMINE_DB_ENCODING' ''
+		else
+			echo >&2
+			echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
+			echo >&2
+			echo >&2 '*** Using sqlite3 as fallback. ***'
+			echo >&2
+
+			adapter='sqlite3'
+			host='localhost'
+			file_env 'REDMINE_DB_PORT' ''
+			file_env 'REDMINE_DB_USERNAME' 'redmine'
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' 'sqlite/redmine.db'
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+
+			mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
+			if [ "$(id -u)" = '0' ]; then
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
+			fi
+		fi
+
+		REDMINE_DB_ADAPTER="$adapter"
+		REDMINE_DB_HOST="$host"
+		echo "$RAILS_ENV:" > config/database.yml
+		for var in \
+			adapter \
+			host \
+			port \
+			username \
+			password \
+			database \
+			encoding \
+		; do
+			env="REDMINE_DB_${var^^}"
+			val="${!env}"
+			[ -n "$val" ] || continue
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
+		done
+	fi
+
+	# install additional gems for Gemfile.local and plugins
+	bundle check || bundle install
+
+	file_env 'REDMINE_SECRET_KEY_BASE'
+	# just use the rails variable rather than trying to put it into a yml file
+	# https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/application.rb#L438
+	# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L484 (rails 7.1-stable)
+	if [ -n "${SECRET_KEY_BASE:-}" ] && [ -n "${REDMINE_SECRET_KEY_BASE:-}" ]; then
+		echo >&2
+		echo >&2 'warning: both SECRET_KEY_BASE and REDMINE_SECRET_KEY_BASE{_FILE} set, only SECRET_KEY_BASE will apply'
+		echo >&2
+	fi
+	: "${SECRET_KEY_BASE:=${REDMINE_SECRET_KEY_BASE:-}}"
+	export SECRET_KEY_BASE
+	if [ -z "$SECRET_KEY_BASE" ]; then
+		# https://github.com/docker-library/redmine/issues/397
+		# empty string is truthy in ruby and so masks the generated fallback config
+		# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L454
+		unset SECRET_KEY_BASE
+		# generate SECRET_KEY_BASE in-file since it is not set or empty; this is not recommended unless the secret_token.rb is saved when container is recreated
+		if [ ! -f config/initializers/secret_token.rb ]; then
+			echo >&2
+			echo >&2 'warning: no *SECRET_KEY_BASE set; running `rake generate_secret_token` to create one in "config/initializers/secret_token.rb"'
+			echo >&2
+			rake generate_secret_token
+		fi
+	fi
+
+	if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+		rake db:migrate
+	fi
+
+	if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
+		rake redmine:plugins:migrate
+	fi
+
+	# remove PID file to enable restarting the container
+	rm -f tmp/pids/server.pid
+fi
+
+exec "$@"

--- a/7.0/trixie/Dockerfile
+++ b/7.0/trixie/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM ruby:3.3-slim-bookworm
+FROM ruby:4.0.6-slim-trixie
 
 # explicitly set uid/gid to guarantee that it won't change in the future
 # the values 999:999 are identical to the current user/group id assigned
@@ -23,10 +23,9 @@ RUN set -eux; \
 		openssh-client \
 		subversion \
 		tini \
+		tzdata-legacy \
 		wget \
 	; \
-# allow imagemagick to use ghostscript for PDF -> PNG thumbnail conversion (4.1+)
-	sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
@@ -71,9 +70,9 @@ RUN set -eux; \
 	chown redmine:redmine "$HOME"; \
 	chmod 1777 "$HOME"
 
-ENV REDMINE_VERSION 6.0.10
-ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-6.0.10.tar.gz
-ENV REDMINE_DOWNLOAD_SHA256 0f3f3a7159188fbd65a365519037ebe6882c6dace78d8630de22c570ff20ca77
+ENV REDMINE_VERSION 7.0.0
+ENV REDMINE_DOWNLOAD_URL https://www.redmine.org/releases/redmine-7.0.0.tar.gz
+ENV REDMINE_DOWNLOAD_SHA256 857e9f8860c31e4c531389e5d93eea26488dba69830484a3b0aa904be615e90a
 ENV RAILS_LOG_TO_STDOUT true
 
 RUN set -eux; \
@@ -93,9 +92,11 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		cargo \
 		default-libmysqlclient-dev \
 		freetds-dev \
 		gcc \
+		libclang-dev \
 		libpq-dev \
 		libsqlite3-dev \
 		libxml2-dev \

--- a/7.0/trixie/docker-entrypoint.sh
+++ b/7.0/trixie/docker-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+# TODO add "-u"
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+isLikelyRedmine=
+case "$1" in
+	rails | rake ) isLikelyRedmine=1 ;;
+	bundle ) if [ "${2:-}" = 'exec' ]; then isLikelyRedmine=1; fi ;; # https://github.com/docker-library/redmine/pull/386 - "bundle exec sidekiq"
+esac
+
+_fix_permissions() {
+	# https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
+	local dirs=( config log public/*assets tmp ) args=()
+	if [ "$(id -u)" = '0' ]; then
+		args+=( ${args[@]:+,} '(' '!' -user redmine -exec chown redmine:redmine '{}' + ')' )
+
+		# https://github.com/docker-library/redmine/issues/268 - scanning "files" might be *really* expensive, so we should skip it if it seems like it's "already correct"
+		local filesOwnerMode
+		filesOwnerMode="$(stat -c '%U:%a' files)"
+		if [ "$filesOwnerMode" != 'redmine:755' ]; then
+			dirs+=( files )
+		fi
+	fi
+	# directories 755, files 644:
+	args+=( ${args[@]:+,} '(' -type d '!' -perm 755 -exec sh -c 'chmod 755 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	args+=( ${args[@]:+,} '(' -type f '!' -perm 644 -exec sh -c 'chmod 644 "$@" 2>/dev/null || :' -- '{}' + ')' )
+	find "${dirs[@]}" "${args[@]}"
+}
+
+# allow the container to be started with `--user`
+if [ -n "$isLikelyRedmine" ] && [ "$(id -u)" = '0' ]; then
+	_fix_permissions
+	exec gosu redmine "$BASH_SOURCE" "$@"
+fi
+
+if [ -n "$isLikelyRedmine" ]; then
+	_fix_permissions
+	if [ ! -f './config/database.yml' ]; then
+		file_env 'REDMINE_DB_MYSQL'
+		file_env 'REDMINE_DB_POSTGRES'
+		file_env 'REDMINE_DB_SQLSERVER'
+
+		if [ "$MYSQL_PORT_3306_TCP" ] && [ -z "$REDMINE_DB_MYSQL" ]; then
+			export REDMINE_DB_MYSQL='mysql'
+		elif [ "$POSTGRES_PORT_5432_TCP" ] && [ -z "$REDMINE_DB_POSTGRES" ]; then
+			export REDMINE_DB_POSTGRES='postgres'
+		fi
+
+		if [ "$REDMINE_DB_MYSQL" ]; then
+			adapter='mysql2'
+			host="$REDMINE_DB_MYSQL"
+			file_env 'REDMINE_DB_PORT' '3306'
+			file_env 'REDMINE_DB_USERNAME' "${MYSQL_ENV_MYSQL_USER:-root}"
+			file_env 'REDMINE_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+			file_env 'REDMINE_DB_DATABASE' "${MYSQL_ENV_MYSQL_DATABASE:-${MYSQL_ENV_MYSQL_USER:-redmine}}"
+			file_env 'REDMINE_DB_ENCODING' ''
+		elif [ "$REDMINE_DB_POSTGRES" ]; then
+			adapter='postgresql'
+			host="$REDMINE_DB_POSTGRES"
+			file_env 'REDMINE_DB_PORT' '5432'
+			file_env 'REDMINE_DB_USERNAME' "${POSTGRES_ENV_POSTGRES_USER:-postgres}"
+			file_env 'REDMINE_DB_PASSWORD' "${POSTGRES_ENV_POSTGRES_PASSWORD}"
+			file_env 'REDMINE_DB_DATABASE' "${POSTGRES_ENV_POSTGRES_DB:-${REDMINE_DB_USERNAME:-}}"
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+		elif [ "$REDMINE_DB_SQLSERVER" ]; then
+			adapter='sqlserver'
+			host="$REDMINE_DB_SQLSERVER"
+			file_env 'REDMINE_DB_PORT' '1433'
+			file_env 'REDMINE_DB_USERNAME' ''
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' ''
+			file_env 'REDMINE_DB_ENCODING' ''
+		else
+			echo >&2
+			echo >&2 'warning: missing REDMINE_DB_MYSQL, REDMINE_DB_POSTGRES, or REDMINE_DB_SQLSERVER environment variables'
+			echo >&2
+			echo >&2 '*** Using sqlite3 as fallback. ***'
+			echo >&2
+
+			adapter='sqlite3'
+			host='localhost'
+			file_env 'REDMINE_DB_PORT' ''
+			file_env 'REDMINE_DB_USERNAME' 'redmine'
+			file_env 'REDMINE_DB_PASSWORD' ''
+			file_env 'REDMINE_DB_DATABASE' 'sqlite/redmine.db'
+			file_env 'REDMINE_DB_ENCODING' 'utf8'
+
+			mkdir -p "$(dirname "$REDMINE_DB_DATABASE")"
+			if [ "$(id -u)" = '0' ]; then
+				find "$(dirname "$REDMINE_DB_DATABASE")" \! -user redmine -exec chown redmine '{}' +
+			fi
+		fi
+
+		REDMINE_DB_ADAPTER="$adapter"
+		REDMINE_DB_HOST="$host"
+		echo "$RAILS_ENV:" > config/database.yml
+		for var in \
+			adapter \
+			host \
+			port \
+			username \
+			password \
+			database \
+			encoding \
+		; do
+			env="REDMINE_DB_${var^^}"
+			val="${!env}"
+			[ -n "$val" ] || continue
+			if [ "$var" != 'adapter' ]; then
+				# https://github.com/docker-library/redmine/issues/353 🙃
+				val='"'"$val"'"'
+				# (only add double quotes to every value *except* `adapter: xxx`)
+			fi
+			echo "  $var: $val" >> config/database.yml
+		done
+	fi
+
+	# install additional gems for Gemfile.local and plugins
+	bundle check || bundle install
+
+	file_env 'REDMINE_SECRET_KEY_BASE'
+	# just use the rails variable rather than trying to put it into a yml file
+	# https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/application.rb#L438
+	# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L484 (rails 7.1-stable)
+	if [ -n "${SECRET_KEY_BASE:-}" ] && [ -n "${REDMINE_SECRET_KEY_BASE:-}" ]; then
+		echo >&2
+		echo >&2 'warning: both SECRET_KEY_BASE and REDMINE_SECRET_KEY_BASE{_FILE} set, only SECRET_KEY_BASE will apply'
+		echo >&2
+	fi
+	: "${SECRET_KEY_BASE:=${REDMINE_SECRET_KEY_BASE:-}}"
+	export SECRET_KEY_BASE
+	if [ -z "$SECRET_KEY_BASE" ]; then
+		# https://github.com/docker-library/redmine/issues/397
+		# empty string is truthy in ruby and so masks the generated fallback config
+		# https://github.com/rails/rails/blob/1aa9987169213ce5ce43c20b2643bc64c235e792/railties/lib/rails/application.rb#L454
+		unset SECRET_KEY_BASE
+		# generate SECRET_KEY_BASE in-file since it is not set or empty; this is not recommended unless the secret_token.rb is saved when container is recreated
+		if [ ! -f config/initializers/secret_token.rb ]; then
+			echo >&2
+			echo >&2 'warning: no *SECRET_KEY_BASE set; running `rake generate_secret_token` to create one in "config/initializers/secret_token.rb"'
+			echo >&2
+			rake generate_secret_token
+		fi
+	fi
+
+	if [ "$1" != 'rake' -a -z "$REDMINE_NO_DB_MIGRATE" ]; then
+		rake db:migrate
+	fi
+
+	if [ "$1" != 'rake' -a -n "$REDMINE_PLUGINS_MIGRATE" ]; then
+		rake redmine:plugins:migrate
+	fi
+
+	# remove PID file to enable restarting the container
+	rm -f tmp/pids/server.pid
+fi
+
+exec "$@"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -41,9 +41,11 @@ RUN groupadd -r -g 999 redmine && useradd -r -g redmine -u 999 redmine
 			# debian packages
 			"bzr",
 			"gsfonts", # for generating PNGs of Gantt charts
-			# redmine needs a rails update that includes https://github.com/rails/rails/pull/57266
-			# before it will handle the renamed timezones (they just fail to show in the redmine selector)
-			if env.variant == "trixie" and IN(env.version; "6.0", "6.1") then
+			# trixie's tzdata drops legacy zone names (e.g. Europe/Kiev) which
+			# older Rails releases still expect; tzdata-legacy restores them so
+			# that `rake time:zones:all` continues to expose the renamed cities
+			# (Kyiv, etc.) in the Redmine timezone selector
+			if env.variant == "trixie" then
 				"tzdata-legacy"
 			else empty end,
 			empty
@@ -252,6 +254,10 @@ RUN set -eux; \
 	gosu redmine bundle config set build.nokogiri --use-system-libraries; \
 {{ ) end -}}
 	gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 	rm ./config/database.yml; \
 # fix permissions for running as an arbitrary user
 	chmod -R ugo=rwX Gemfile.lock "$GEM_HOME"; \
@@ -270,11 +276,12 @@ RUN set -eux; \
 			$1 == "libc.so" { next } \
 {{ ) end -}}
 			system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+			system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
 			{ print "so:" $1 } \
 		' \
 	)"; \
 	apk add --no-network --virtual .redmine-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
+	apk del --no-network .build-deps
 {{ ) else ( -}}
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
@@ -288,10 +295,8 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 {{ ) end -}}
-	# verify Kyiv timezone isn't missing
-	gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'
 
 VOLUME /usr/src/redmine/files
 

--- a/versions.json
+++ b/versions.json
@@ -30,5 +30,21 @@
       "alpine3.23"
     ],
     "version": "6.1.3"
+  },
+  "7.0": {
+    "alpine": "3.24",
+    "debian": "trixie",
+    "downloadUrl": "https://www.redmine.org/releases/redmine-7.0.0.tar.gz",
+    "ruby": {
+      "version": "4.0.6"
+    },
+    "sha256": "857e9f8860c31e4c531389e5d93eea26488dba69830484a3b0aa904be615e90a",
+    "variants": [
+      "trixie",
+      "bookworm",
+      "alpine3.24",
+      "alpine3.23"
+    ],
+    "version": "7.0.0"
   }
 }

--- a/versions.sh
+++ b/versions.sh
@@ -21,6 +21,10 @@ declare -A alpineVersions=(
 # see https://www.redmine.org/projects/redmine/wiki/redmineinstall
 defaultRubyVersion='3.4'
 declare -A rubyVersions=(
+	# Redmine 7.0 requires Ruby 3.2+; Ruby 4.0.0-4.0.3 has a wiki rendering
+	# regression (https://www.redmine.org/issues/43737), fixed in 4.0.4+.
+	# Pinning to the exact patch until upstream policy for this repo is defined.
+	[7.0]='4.0.6'
 	[6.0]='3.3'
 	#[5.1]='3.2'
 	#[5.0]='3.1'


### PR DESCRIPTION
## Summary

Adds Redmine **7.0.0** (released 2026-06-30) to `versions.json` / `versions.sh`
and applies three small template fixes required by the new stack (Rails 8.1
on Debian trixie + musl/Alpine).

## What's new

### `versions.json` / `versions.sh`

* New `"7.0"` entry pinned to `redmine-7.0.0.tar.gz`
  (sha256 `857e9f8860c31e4c531389e5d93eea26488dba69830484a3b0aa904be615e90a`).
* Variants: `trixie`, `bookworm`, `alpine3.24`, `alpine3.23`.
* Ruby pinned to **`4.0.6`** (not the usual `X.Y` alias) — see rationale below.

#### Ruby version rationale

Redmine 7.0 [requires Ruby 3.2+ and Rails 8.1][1]. Ruby 4.0 is officially
supported, but versions 4.0.0 through 4.0.3 have a wiki rendering regression
tracked as [Redmine issue #43737][2], fixed in 4.0.4. To guarantee the built
image does not ship a broken wiki, the entry is pinned to the exact patch
`4.0.6` rather than the `4.0` alias. I've left a comment in `versions.sh` so
maintainers can relax the pin (e.g. back to `'4.0'`) once repo policy allows
it or once the older 4.0.x images fall out of Docker Hub.

[1]: https://www.redmine.org/projects/redmine/wiki/RedmineInstall
[2]: https://www.redmine.org/issues/43737

## Template fixes (`Dockerfile.template`)

All three changes are needed to get **any** 7.0 variant to build; two of them
also mildly improve correctness for existing 6.0/6.1 variants.

### 1. `tzdata-legacy` is required for **all** trixie versions, not just 6.x

The current template only installs `tzdata-legacy` on trixie for Redmine 6.0
and 6.1, with a comment saying that once Rails picks up
[rails/rails#57266][3] the package will no longer be needed.

That assumption doesn't hold in practice: even on Rails 8.1.3
(Redmine 7.0 stack), `bundle exec rake time:zones:all` does **not** emit
`Kyiv` on trixie unless `tzdata-legacy` is installed, because the legacy
IANA name `Europe/Kiev` is what `ActiveSupport::TimeZone::MAPPING` uses to
resolve Kyiv. Removing the version guard fixes the 7.0 build and keeps the
existing 6.x behaviour unchanged.

```diff
-# redmine needs a rails update that includes https://github.com/rails/rails/pull/57266
-# before it will handle the renamed timezones (they just fail to show in the redmine selector)
-if env.variant == "trixie" and IN(env.version; "6.0", "6.1") then
+# trixie's tzdata drops legacy zone names (e.g. Europe/Kiev) which
+# older Rails releases still expect; tzdata-legacy restores them so
+# that `rake time:zones:all` continues to expose the renamed cities
+# (Kyiv, etc.) in the Redmine timezone selector
+if env.variant == "trixie" then
     "tzdata-legacy"
 else empty end,
```

[3]: https://github.com/rails/rails/pull/57266

### 2. Run the Kyiv sanity check **before** removing the stub `database.yml`

Rails 8.1 (used by Redmine 7.0) tightened the requirements for rake tasks:
even task-agnostic ones like `time:zones:all` now abort with
`Please configure your config/database.yml first` when the file is missing.

The template currently deletes the stub `database.yml` (right after
`bundle install`) and only runs the Kyiv check at the very end of the RUN
step, which fails on 7.0. Moving the check up — immediately after
`bundle install`, while the stub is still there — preserves the check for
older versions and unblocks 7.0.

```diff
 gosu redmine bundle install --jobs "$(nproc)"; \
+# verify Kyiv timezone isn't missing; must run BEFORE removing the stub
+# database.yml because Redmine 7.0+ (Rails 8.1) refuses to run rake tasks
+# without a database configuration
+gosu redmine bundle exec rake time:zones:all | grep -q 'Kyiv'; \
 rm ./config/database.yml; \
```

The corresponding `; \` at the end of the old `apk del`/`apt-get purge`
lines is dropped since they're now the terminal commands of the RUN step.

### 3. Alpine `scanelf` filter: skip SONAMEs vendored by gems

**Symptom** (7.0/alpine3.23 and 7.0/alpine3.24):

```
ERROR: unable to select packages:
  so:libpq-ruby-pg.so.1 (no such package):
    required by: .redmine-rundeps-...[so:libpq-ruby-pg.so.1]
```

**Cause**: `pg` gem 1.6.3 vendors its own libpq built with a private
SONAME (`libpq-ruby-pg.so.1`) placed inside the gem tree at
`/usr/local/bundle/gems/pg-1.6.3/lib/pg/`. The template's runtime-dep
discovery runs:

```sh
scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/bundle/gems
```

…and then filters out well-known things (`libc.so`, files present in
`/usr/local/lib/`). The vendored libpq lives under `/usr/local/bundle/…`,
not `/usr/local/lib/`, so it survives the filter and gets passed to
`apk add`, which of course can't find a package providing that name.

The Debian flow is unaffected because it uses `ldd` (which returns resolved
paths) and already excludes anything under `/usr/local/`.

**Fix**: extend the awk filter with one extra line that also excludes any
SONAME already shipped under `/usr/local/bundle`:

```diff
 system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } \
+system("find /usr/local/bundle -name " $1 " -print -quit 2>/dev/null | grep -q .") == 0 { next } \
 { print "so:" $1 } \
```

I re-ran the 6.1/alpine3.24 build with the updated template to confirm no
regression on older versions.

## Validation

I regenerated all 12 Dockerfiles via `apply-templates.sh` and built every
variant successfully with `podman`:

| Variant             | Build | Ruby   | Rails  | `time:zones:all` includes Kyiv |
|---------------------|:-----:|--------|--------|:------------------------------:|
| `7.0/trixie`        | ✅    | 4.0.6  | 8.1.3  | ✅                             |
| `7.0/bookworm`      | ✅    | 4.0.6  | 8.1.3  | ✅                             |
| `7.0/alpine3.24`    | ✅    | 4.0.6  | 8.1.3  | ✅                             |
| `7.0/alpine3.23`    | ✅    | 4.0.6  | 8.1.3  | ✅                             |
| `6.0/trixie`        | ✅    | (regression check — still builds after template change) |
| `6.0/bookworm`      | ✅    | (regression check — still builds after template change) |
| `6.0/alpine3.24`    | ✅    | (regression check — still builds after template change) |
| `6.0/alpine3.23`    | ✅    | (regression check — still builds after template change) |
| `6.1/trixie`        | ✅    | (regression check — still builds after template change) |
| `6.1/bookworm`      | ✅    | (regression check — still builds after template change) |
| `6.1/alpine3.24`    | ✅    | (regression check — still builds after template change) |
| `6.1/alpine3.23`    | ✅    | (regression check — still builds after template change) |

## Notes for the maintainer

* Happy to split this into two PRs if you'd prefer to review "add 7.0"
  and "template fixes for trixie / alpine" separately — the diff is
  already logically partitioned.
* The Ruby pin (`4.0.6` vs `4.0`) is the only decision that depends on
  repo policy; feel free to change it if you're comfortable tracking the
  major.minor alias.